### PR TITLE
make: fix CAs copy issue

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ prepare-for-rootfs: examples
 	@mkdir -p $(OUTPUT_DIR)/ta
 	@mkdir -p $(OUTPUT_DIR)/ca
 	@for example in $(EXAMPLE_LIST); do \
-		if [ -e $$example/host/$$example ]; then \
+		if [ -e $$example/host/optee_$$example ]; then \
 			cp -p $$example/host/optee_$$example $(OUTPUT_DIR)/ca/; \
 		fi; \
 		cp -pr $$example/ta/*.ta $(OUTPUT_DIR)/ta/; \


### PR DESCRIPTION
Seems, that something went wrong when addressing last comments in the previous PR, and `optee_` prefix was unintentionally deleted

`Signed-off-by: Igor Opaniuk <igor.opaniuk@linaro.org>`