### PR TITLE
Add command to determine EXAMPLE_LIST

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,10 +2,7 @@ export V ?= 0
 
 OUTPUT_DIR := $(CURDIR)/out
 
-EXAMPLE_LIST := hello_world
-EXAMPLE_LIST += random
-EXAMPLE_LIST += aes
-EXAMPLE_LIST += hotp
+EXAMPLE_LIST := $(subst /,,$(dir $(wildcard */Makefile)))
 
 .PHONY: all
 all: examples prepare-for-rootfs


### PR DESCRIPTION
This change decouples the actual examples from the optee_examples folder.  I have added `EXCLUDE_DIRS` to exclude special folders like `out` and `docs`.