### PR TITLE
optee_random: fix compilation error with GCC 4.9

### DIFF
--- a/random/host/main.c
+++ b/random/host/main.c
@@ -44,6 +44,7 @@ int main(int argc, char *argv[])
 	TEEC_UUID uuid = TA_RANDOM_UUID;
 	uint8_t random_uuid[16] = { 0 };
 	uint32_t err_origin;
+	int i;
 
 	/* Initialize a context connecting us to the TEE */
 	res = TEEC_InitializeContext(NULL, &ctx);
@@ -92,7 +93,7 @@ int main(int argc, char *argv[])
 			res, err_origin);
 
 	printf("TA generated UUID value = 0x");
-	for (int i = 0; i < 16; i++)
+	for (i = 0; i < 16; i++)
 		printf("%x", random_uuid[i]);
 	printf("\n");
 


### PR DESCRIPTION
Fixes the following error:

main.c:95:2: error: 'for' loop initial declarations are only allowed in C99 or C11 mode
  for (int i = 0; i < 16; i++)
  ^
main.c:95:2: note: use option -std=c99, -std=gnu99, -std=c11 or -std=gnu11 to compile your code

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>