### PR TITLE
Use "make --no-builtin-variables" to build client applications

### DIFF
--- a/aes/Makefile
+++ b/aes/Makefile
@@ -6,7 +6,7 @@ TA_CROSS_COMPILE ?= $(CROSS_COMPILE)
 
 .PHONY: all
 all:
-	$(MAKE) -C host CROSS_COMPILE="$(HOST_CROSS_COMPILE)"
+	$(MAKE) -C host CROSS_COMPILE="$(HOST_CROSS_COMPILE)" --no-builtin-variables
 	$(MAKE) -C ta CROSS_COMPILE="$(TA_CROSS_COMPILE)"
 
 .PHONY: clean

--- a/aes/host/Makefile
+++ b/aes/host/Makefile
@@ -23,3 +23,6 @@ $(BINARY): $(OBJS)
 .PHONY: clean
 clean:
 	rm -f $(OBJS) $(BINARY)
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@

--- a/hello_world/Makefile
+++ b/hello_world/Makefile
@@ -6,7 +6,7 @@ TA_CROSS_COMPILE ?= $(CROSS_COMPILE)
 
 .PHONY: all
 all:
-	$(MAKE) -C host CROSS_COMPILE="$(HOST_CROSS_COMPILE)"
+	$(MAKE) -C host CROSS_COMPILE="$(HOST_CROSS_COMPILE)" --no-builtin-variables
 	$(MAKE) -C ta CROSS_COMPILE="$(TA_CROSS_COMPILE)"
 
 .PHONY: clean

--- a/hello_world/host/Makefile
+++ b/hello_world/host/Makefile
@@ -23,3 +23,6 @@ $(BINARY): $(OBJS)
 .PHONY: clean
 clean:
 	rm -f $(OBJS) $(BINARY)
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@

--- a/hotp/Makefile
+++ b/hotp/Makefile
@@ -6,7 +6,7 @@ TA_CROSS_COMPILE ?= $(CROSS_COMPILE)
 
 .PHONY: all
 all:
-	$(MAKE) -C host CROSS_COMPILE="$(HOST_CROSS_COMPILE)"
+	$(MAKE) -C host CROSS_COMPILE="$(HOST_CROSS_COMPILE)" --no-builtin-variables
 	$(MAKE) -C ta CROSS_COMPILE="$(TA_CROSS_COMPILE)"
 
 .PHONY: clean

--- a/hotp/host/Makefile
+++ b/hotp/host/Makefile
@@ -23,3 +23,6 @@ $(BINARY): $(OBJS)
 .PHONY: clean
 clean:
 	rm -f $(OBJS) $(BINARY)
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@

--- a/random/Makefile
+++ b/random/Makefile
@@ -6,7 +6,7 @@ TA_CROSS_COMPILE ?= $(CROSS_COMPILE)
 
 .PHONY: all
 all:
-	$(MAKE) -C host CROSS_COMPILE="$(HOST_CROSS_COMPILE)"
+	$(MAKE) -C host CROSS_COMPILE="$(HOST_CROSS_COMPILE)" --no-builtin-variables
 	$(MAKE) -C ta CROSS_COMPILE="$(TA_CROSS_COMPILE)"
 
 .PHONY: clean

--- a/random/host/Makefile
+++ b/random/host/Makefile
@@ -23,3 +23,6 @@ $(BINARY): $(OBJS)
 .PHONY: clean
 clean:
 	rm -f $(OBJS) $(BINARY)
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@


### PR DESCRIPTION
Commit 1d7d9ad85650 ("host/Makefiles: Allow CC variable to be derived
from env") changed the client application Makfiles so that $(CC) will
not be modified if already set. The intent was to take into account
the values derived from the environment or the command line.
Unfortunately, the "?=" syntax will also consider 'default' (built-in)
variables as shown in this example:

  $ cat Makefile
  $(info CC=$(CC) origin: $(origin CC))
  CC ?= foo
  $(info CC=$(CC) origin: $(origin CC))

  all:
  $ make
  CC=cc origin: default
  CC=cc origin: default
  make: Nothing to be done for 'all'.

As a result, unless CC is specified via the environment or the command
line, its value defaults to 'cc' which is not what we want for cross
compilation.

This commit fixes the issue in a similar way to optee_test, by
disabling built-in variables. This in turn requires adding explicit
compilation rules (%.o: %.c).

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
Fixes: 1d7d9ad85650 ("host/Makefiles: Allow CC variable to be derived from env")