### PR TITLE
ta/Makefiles: Set LDFLAGS to null before importing ta make scripts

### DIFF
--- a/aes/Makefile
+++ b/aes/Makefile
@@ -7,7 +7,7 @@ TA_CROSS_COMPILE ?= $(CROSS_COMPILE)
 .PHONY: all
 all:
 	$(MAKE) -C host CROSS_COMPILE="$(HOST_CROSS_COMPILE)" --no-builtin-variables
-	$(MAKE) -C ta CROSS_COMPILE="$(TA_CROSS_COMPILE)"
+	$(MAKE) -C ta CROSS_COMPILE="$(TA_CROSS_COMPILE)" LDFLAGS=""
 
 .PHONY: clean
 clean:

--- a/hello_world/Makefile
+++ b/hello_world/Makefile
@@ -7,7 +7,7 @@ TA_CROSS_COMPILE ?= $(CROSS_COMPILE)
 .PHONY: all
 all:
 	$(MAKE) -C host CROSS_COMPILE="$(HOST_CROSS_COMPILE)" --no-builtin-variables
-	$(MAKE) -C ta CROSS_COMPILE="$(TA_CROSS_COMPILE)"
+	$(MAKE) -C ta CROSS_COMPILE="$(TA_CROSS_COMPILE)" LDFLAGS=""
 
 .PHONY: clean
 clean:

--- a/hotp/Makefile
+++ b/hotp/Makefile
@@ -7,7 +7,7 @@ TA_CROSS_COMPILE ?= $(CROSS_COMPILE)
 .PHONY: all
 all:
 	$(MAKE) -C host CROSS_COMPILE="$(HOST_CROSS_COMPILE)" --no-builtin-variables
-	$(MAKE) -C ta CROSS_COMPILE="$(TA_CROSS_COMPILE)"
+	$(MAKE) -C ta CROSS_COMPILE="$(TA_CROSS_COMPILE)" LDFLAGS=""
 
 .PHONY: clean
 clean:

--- a/random/Makefile
+++ b/random/Makefile
@@ -7,7 +7,7 @@ TA_CROSS_COMPILE ?= $(CROSS_COMPILE)
 .PHONY: all
 all:
 	$(MAKE) -C host CROSS_COMPILE="$(HOST_CROSS_COMPILE)" --no-builtin-variables
-	$(MAKE) -C ta CROSS_COMPILE="$(TA_CROSS_COMPILE)"
+	$(MAKE) -C ta CROSS_COMPILE="$(TA_CROSS_COMPILE)" LDFLAGS=""
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Yocto can set LDFLAGS to values that are incompatible with building a TA.
This patch ensures the LDFLAGS from the environment is unset prior to
importing make script settings, thus allowing us to compile up the TAs the
way we need to, while still accepting the LDFLAGS from yocto for the
host-side binaries.

This fix is exactly what we do in optee-test for this same issue.

Signed-off-by: Bryan O'Donoghue <bryan.odonoghue@linaro.org>