### PR TITLE
IV In AES CRT mode is always 128 bits regarldless the key size

### DIFF
--- a/aes/host/main.c
+++ b/aes/host/main.c
@@ -37,6 +37,7 @@
 
 #define AES_TEST_BUFFER_SIZE	4096
 #define AES_TEST_KEY_SIZE	16
+#define AES_BLOCK_SIZE		16
 
 #define DECODE			0
 #define ENCODE			1
@@ -161,7 +162,7 @@ int main(int argc, char *argv[])
 {
 	struct test_ctx ctx;
 	char key[AES_TEST_KEY_SIZE];
-	char iv[AES_TEST_KEY_SIZE];
+	char iv[AES_BLOCK_SIZE];
 	char clear[AES_TEST_BUFFER_SIZE];
 	char ciph[AES_TEST_BUFFER_SIZE];
 	char temp[AES_TEST_BUFFER_SIZE];
@@ -178,7 +179,7 @@ int main(int argc, char *argv[])
 
 	printf("Reset ciphering operation in TA (provides the initial vector)\n");
 	memset(iv, 0, sizeof(iv)); /* Load some dummy value */
-	set_iv(&ctx, iv, AES_TEST_KEY_SIZE);
+	set_iv(&ctx, iv, AES_BLOCK_SIZE);
 
 	printf("Encore buffer from TA\n");
 	memset(clear, 0x5a, sizeof(clear)); /* Load some dummy value */
@@ -193,7 +194,7 @@ int main(int argc, char *argv[])
 
 	printf("Reset ciphering operation in TA (provides the initial vector)\n");
 	memset(iv, 0, sizeof(iv)); /* Load some dummy value */
-	set_iv(&ctx, iv, AES_TEST_KEY_SIZE);
+	set_iv(&ctx, iv, AES_BLOCK_SIZE);
 
 	printf("Decode buffer from TA\n");
 	memset(clear, 0x5a, sizeof(clear)); /* Load some dummy value */


### PR DESCRIPTION
The initial vector in AES CRT mode is the first data block and
therefore has the size of block size as opposed ot the size of
the key. While Rijndael does support different block sizes AES
only supports 128 bits (16 bytes) block. Even with larger keys
sizes ( e.g. 192 or 256 bits) the block size remains 128 bits.
This change introduced a new constant AES_BLOCK_SIZE  and uses
this for IV related operations.