### PR TITLE
hotp: fix sign compare error

### DIFF
--- a/hotp/host/main.c
+++ b/hotp/host/main.c
@@ -44,7 +44,7 @@ int main(void)
 	TEEC_Session sess;
 	TEEC_UUID uuid = TA_HOTP_UUID;
 
-	int i;
+	size_t i;
 	uint32_t err_origin;
 	uint32_t hotp_value;
 


### PR DESCRIPTION
optee_examples/hotp/host/main.c:92:16: error: comparison of integers of different signs: 'int' and 'unsigned long' [-Werror,-Wsign-compare]
        for (i = 0; i < sizeof(rfc4226_test_values) / sizeof(struct test_value);
                    ~ ^ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

Signed-off-by: Victor Chong <victor.chong@linaro.org>