### PR TITLE
secure_storage: Add CMakeLists.txt

### DIFF
--- a/secure_storage/CMakeLists.txt
+++ b/secure_storage/CMakeLists.txt
@@ -1,0 +1,13 @@
+project (secure_storage C)
+
+set (SRC host/main.c)
+
+add_executable (${PROJECT_NAME} ${SRC})
+
+target_include_directories(${PROJECT_NAME}
+			   PRIVATE ta/include
+			   PRIVATE include)
+
+target_link_libraries (${PROJECT_NAME} PRIVATE teec)
+
+install (TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})


### PR DESCRIPTION
This will make the host binary end up in the Buildroot filesystem.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>