### PR TITLE
Remove misleading TA properties

### DIFF
--- a/hello_world/ta/user_ta_header_defines.h
+++ b/hello_world/ta/user_ta_header_defines.h
@@ -49,10 +49,18 @@
 /* Provisioned heap size for TEE_Malloc() and friends */
 #define TA_DATA_SIZE			(32 * 1024)
 
-/* Extra properties (give a version id and a string name) */
+/* The gpd.ta.version property */
+#define TA_VERSION	"1.0"
+
+/* The gpd.ta.description property */
+#define TA_DESCRIPTION	"Example of OP-TEE Hello World Trusted Application"
+
+/* Extra properties */
 #define TA_CURRENT_TA_EXT_PROPERTIES \
-    { "gp.ta.description", USER_TA_PROP_TYPE_STRING, \
-        "Example of OP-TEE Hello World Trusted Application" }, \
-    { "gp.ta.version", USER_TA_PROP_TYPE_U32, &(const uint32_t){ 0x0010 } }
+    { "org.linaro.optee.examples.hello_world.property1", \
+	USER_TA_PROP_TYPE_STRING, \
+        "Some string" }, \
+    { "org.linaro.optee.examples.hello_world.property2", \
+	USER_TA_PROP_TYPE_U32, &(const uint32_t){ 0x0010 } }
 
 #endif /* USER_TA_HEADER_DEFINES_H */

--- a/hotp/ta/user_ta_header_defines.h
+++ b/hotp/ta/user_ta_header_defines.h
@@ -22,10 +22,4 @@
 /* Provisioned heap size for TEE_Malloc() and friends */
 #define TA_DATA_SIZE	(32 * 1024)
 
-/* Extra properties (give a version id and a string name) */
-#define TA_CURRENT_TA_EXT_PROPERTIES \
-	{ "gp.ta.description", USER_TA_PROP_TYPE_STRING, \
-	  "HMAC-Based One-Time Password Algorithm (RFC4226)" }, \
-	{ "gp.ta.version", USER_TA_PROP_TYPE_U32, &(const uint32_t){ 0x0010 } }
-
 #endif

--- a/random/ta/user_ta_header_defines.h
+++ b/random/ta/user_ta_header_defines.h
@@ -49,10 +49,4 @@
 /* Provisioned heap size for TEE_Malloc() and friends */
 #define TA_DATA_SIZE			(32 * 1024)
 
-/* Extra properties (give a version id and a string name) */
-#define TA_CURRENT_TA_EXT_PROPERTIES \
-    { "gp.ta.description", USER_TA_PROP_TYPE_STRING, \
-      "Example of a TA that returns the output from TEE_GenerateRandom" }, \
-    { "gp.ta.version", USER_TA_PROP_TYPE_U32, &(const uint32_t){ 0x0010 } }
-
 #endif /* USER_TA_HEADER_DEFINES_H */


### PR DESCRIPTION
```
Some of our example TAs define the following properties:
 - "gp.ta.description" (type: string)
 - "gp.ta.version" (type: unsigned 32-bit integer)

This is misleading, because these are *not* the standard description and
version properties defined by the GP Internal Core API specification. The
standard ones are:
 - "gpd.ta.description" (type: string)
 - "gpd.ta.version" (type: string)
OP-TEE TAs should use the TA_DESCRIPTION and TA_VERSION macros to define
them.

This commit gets rid of the misleading properties. Instead, TA_DESCRIPTION
and TA_VERSION are set in the hello_world application. To still illustrate
the mechanism used to define non-standard properties, we add a couple of
values with names that follow the recommended reverse domain name
convention. Other TAs are left with no additional properties and default
version and description for simplicity.

Signed-off-by: Jerome Forissier <jerome.forissier@linaro.org>
```