### PR TITLE
Fix incompatible pointer types compiling error in NXP flex-build system.

### DIFF
--- a/secure_storage/ta/secure_storage_ta.c
+++ b/secure_storage/ta/secure_storage_ta.c
@@ -146,7 +146,7 @@ static TEE_Result read_raw_object(uint32_t param_types, TEE_Param params[4])
 	TEE_ObjectHandle object;
 	TEE_ObjectInfo object_info;
 	TEE_Result res;
-	size_t read_bytes;
+	uint32_t read_bytes;
 	char *obj_id;
 	size_t obj_id_sz;
 	char *data;
@@ -202,7 +202,7 @@ static TEE_Result read_raw_object(uint32_t param_types, TEE_Param params[4])
 	res = TEE_ReadObjectData(object, data, object_info.dataSize,
 				 &read_bytes);
 	if (res != TEE_SUCCESS || read_bytes != object_info.dataSize) {
-		EMSG("TEE_ReadObjectData failed 0x%08x, read %u over %u",
+		EMSG("TEE_ReadObjectData failed 0x%08x, read %" PRIu32 " over %u",
 				res, read_bytes, object_info.dataSize);
 		goto exit;
 	}


### PR DESCRIPTION
This fix is to avoid the compiling error when the code is built with NXP LSDK (flexbbuild system with gcc-aach64-linux-gnu) as: 

"secure_storage_ta.c:203:6: error: passing argument 4 of ‘TEE_ReadObjectData’ from incompatible pointer type [-Werror=incompatible-pointer-types]
      &read_bytes);
...
secure_storage_ta.c:205:8: error: format ‘%u’ expects argument of type ‘unsigned int’, but argument 7 has type ‘size_t {aka long unsigned int}’ [-Werror=format=]
   EMSG("TEE_ReadObjectData failed 0x%08x, read %u over %u","