### PR TITLE
cmake: prefix host tools file names with optee_example_

### DIFF
--- a/acipher/CMakeLists.txt
+++ b/acipher/CMakeLists.txt
@@ -1,4 +1,4 @@
-project (acipher C)
+project (optee_example_acipher C)
 
 set (SRC host/main.c)
 

--- a/aes/CMakeLists.txt
+++ b/aes/CMakeLists.txt
@@ -1,4 +1,4 @@
-project (aes C)
+project (optee_example_aes C)
 
 set (SRC host/main.c)
 

--- a/hello_world/CMakeLists.txt
+++ b/hello_world/CMakeLists.txt
@@ -1,4 +1,4 @@
-project (hello_world C)
+project (optee_example_hello_world C)
 
 set (SRC host/main.c)
 

--- a/hotp/CMakeLists.txt
+++ b/hotp/CMakeLists.txt
@@ -1,4 +1,4 @@
-project (hotp C)
+project (optee_example_hotp C)
 
 set (SRC host/main.c)
 

--- a/random/CMakeLists.txt
+++ b/random/CMakeLists.txt
@@ -1,4 +1,4 @@
-project (random C)
+project (optee_example_random C)
 
 set (SRC host/main.c)
 

--- a/secure_storage/CMakeLists.txt
+++ b/secure_storage/CMakeLists.txt
@@ -1,4 +1,4 @@
-project (secure_storage C)
+project (optee_example_secure_storage C)
 
 set (SRC host/main.c)
 


### PR DESCRIPTION
Sync the CMake build with the GNU make and the Android make
process. All client applications generated by this package
are prefixed with optee_example_.

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>