### PR TITLE
acipher: fix type in error trace

### DIFF
--- a/acipher/host/main.c
+++ b/acipher/host/main.c
@@ -104,7 +104,7 @@ int main(int argc, char *argv[])
 
 	op.params[1].tmpref.buffer = malloc(op.params[1].tmpref.size);
 	if (!op.params[1].tmpref.buffer)
-		err(1, "Cannot allocate out buffer of size %" PRId32,
+		err(1, "Cannot allocate out buffer of size %zu",
 		    op.params[1].tmpref.size);
 
 	res = TEEC_InvokeCommand(&sess, TA_ACIPHER_CMD_ENCRYPT, &op, &eo);


### PR DESCRIPTION
Fix build warning reported by GCC-8.2 as:

/path/to/optee_examples/acipher/host/main.c: In function ‘main’:
/path/to/optee_examples/acipher/host/main.c:108:7: warning: format ‘%d’ expects argument of type ‘int’, but argument 3 has type ‘size_t’ [-Wformat=]
       op.params[1].tmpref.size);
       ^

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>