### PR TITLE
[RFC] cmake: build TAs from CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,6 +25,49 @@ if(CCACHE_FOUND)
 	set_property(GLOBAL PROPERTY RULE_LAUNCH_LINK ccache)
 endif(CCACHE_FOUND)
 
+
+# TA must be built from TA SDK based on GNU Makefiles and not compatible with
+# a CMake build process. Using this macro. Unless -DBUILD_OPTEE_TAS=n, TAs
+# are built.
+#
+# Helper macro define_ta_source_dir() ease integzation of TA source trees.
+#
+# Using macro define_ta_source_dir(TA_NAME TA_SOURCE_PATH)
+# - 'make all' will build TA from source
+# - 'make install' will install TA binary file (*.ta) in /lib/optee_armtz
+# - 'make clean' will clean TA build directory
+if (NOT BUILD_OPTEE_TAS)
+	set (BUILD_OPTEE_TAS y)
+endif ()
+
+macro (define_ta_source_dir TA_NAME TA_SOURCE_PATH)
+
+	if (BUILD_OPTEE_TAS)
+	project (optee_example_${TA_NAME}_ta)
+
+	set_directory_properties(
+		PROPERTIES ADDITIONAL_MAKE_CLEAN_FILES "${CMAKE_CURRENT_SOURCE_DIR}/${TA_SOURCE_PATH}/out"
+		)
+
+	add_custom_target (
+		build-optee_example_${TA_NAME}_ta ALL
+		)
+
+	add_custom_command (
+		TARGET build-optee_example_${TA_NAME}_ta
+		COMMAND make -C ${TA_SOURCE_PATH} O=${CMAKE_CURRENT_SOURCE_DIR}/${TA_SOURCE_PATH}/out TA_DEV_KIT_DIR=${OPTEE_EXAMPLES_SDK} all
+		COMMENT "Compiling Trusted Applications"
+		VERBATIM
+		)
+
+	install (
+		DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/${TA_SOURCE_PATH}/out/ DESTINATION /lib/optee_armtz
+	        FILES_MATCHING PATTERN "out/*.ta"
+		)
+	endif () # BUILD_OPTEE_TAS
+
+endmacro ()
+
 file(GLOB dirs *)
 foreach(dir ${dirs})
 	if(EXISTS ${dir}/CMakeLists.txt)

--- a/acipher/CMakeLists.txt
+++ b/acipher/CMakeLists.txt
@@ -1,3 +1,4 @@
+# Client Application
 project (optee_example_acipher C)
 
 set (SRC host/main.c)
@@ -11,3 +12,6 @@ target_include_directories(${PROJECT_NAME}
 target_link_libraries (${PROJECT_NAME} PRIVATE teec)
 
 install (TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+# Trusted Application
+define_ta_source_dir(acipher "ta")

--- a/aes/CMakeLists.txt
+++ b/aes/CMakeLists.txt
@@ -1,3 +1,4 @@
+# Client Application
 project (optee_example_aes C)
 
 set (SRC host/main.c)
@@ -11,3 +12,6 @@ target_include_directories(${PROJECT_NAME}
 target_link_libraries (${PROJECT_NAME} PRIVATE teec)
 
 install (TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+# Trusted Application
+define_ta_source_dir(aes "ta")

--- a/hello_world/CMakeLists.txt
+++ b/hello_world/CMakeLists.txt
@@ -1,3 +1,4 @@
+# Client Application
 project (optee_example_hello_world C)
 
 set (SRC host/main.c)
@@ -11,3 +12,6 @@ target_include_directories(${PROJECT_NAME}
 target_link_libraries (${PROJECT_NAME} PRIVATE teec)
 
 install (TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+# Trusted Application
+define_ta_source_dir(hello_world "ta/")

--- a/hotp/CMakeLists.txt
+++ b/hotp/CMakeLists.txt
@@ -1,3 +1,4 @@
+# Client Application
 project (optee_example_hotp C)
 
 set (SRC host/main.c)
@@ -11,3 +12,6 @@ target_include_directories(${PROJECT_NAME}
 target_link_libraries (${PROJECT_NAME} PRIVATE teec)
 
 install (TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+# Trusted Application
+define_ta_source_dir(hotp "ta/")

--- a/random/CMakeLists.txt
+++ b/random/CMakeLists.txt
@@ -1,3 +1,4 @@
+# Client Application
 project (optee_example_random C)
 
 set (SRC host/main.c)
@@ -11,3 +12,5 @@ target_include_directories(${PROJECT_NAME}
 target_link_libraries (${PROJECT_NAME} PRIVATE teec)
 
 install (TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
+# Trusted Application
+define_ta_source_dir(random "ta/")

--- a/secure_storage/CMakeLists.txt
+++ b/secure_storage/CMakeLists.txt
@@ -1,3 +1,4 @@
+# Client Application
 project (optee_example_secure_storage C)
 
 set (SRC host/main.c)
@@ -11,3 +12,6 @@ target_include_directories(${PROJECT_NAME}
 target_link_libraries (${PROJECT_NAME} PRIVATE teec)
 
 install (TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})
+
+# Trusted Application
+define_ta_source_dir(secure_storage "ta")


### PR DESCRIPTION
TA SDK does not yet support CMake build environment. This change allows
one to build xhost tools and TAs images from CMake using custom
target and commands in CMake scripts.

A equivalent RFC is proposed on optee_test: https://github.com/OP-TEE/optee_test/pull/337.