### PR TITLE
Aosp ss fixes

### DIFF
--- a/secure_storage/Android.mk
+++ b/secure_storage/Android.mk
@@ -13,6 +13,7 @@ LOCAL_C_INCLUDES := $(LOCAL_PATH)/ta/include \
 
 LOCAL_SHARED_LIBRARIES := libteec
 LOCAL_MODULE := optee_example_secure_storage
+LOCAL_VENDOR_MODULE := true
 LOCAL_MODULE_TAGS := optional
 include $(BUILD_EXECUTABLE)
 

--- a/secure_storage/host/main.c
+++ b/secure_storage/host/main.c
@@ -166,7 +166,7 @@ TEEC_Result delete_secure_object(struct test_ctx *ctx, char *id)
 
 #define TEST_OBJECT_SIZE	7000
 
-int main(int argc, char *argv[])
+int main(void)
 {
 	struct test_ctx ctx;
 	char obj1_id[] = "object#1";		/* string identification for the object */


### PR DESCRIPTION
Resolves this:
```make
external/optee_examples/secure_storage/Android.mk: error: optee_example_secure_storage (native:platform) should not link to libteec (native:vendor)
[ 15% 2/13] target  C: optee_example_secure_storage <= external/optee_examples/secure_storage/host/main.c                      
FAILED: out/target/product/hikey/obj/EXECUTABLES/optee_example_secure_storage_intermediates/host/main.o                                               
/bin/bash -c "PWD=/proc/self/cwd prebuilts/misc/linux-x86/ccache/ccache prebuilts/clang/host/linux-x86/clang-4691093/bin/clang       -I external/optee_examples/secur
e_storage/ta/include -I external/optee_examples/secure_storage/../../optee_client/out/export/include -I external/optee_examples/secure_storage -I out/target/product/
hikey/obj/EXECUTABLES/optee_example_secure_storage_intermediates -I out/target/product/hikey/gen/EXECUTABLES/optee_example_secure_storage_intermediates -I libnativeh
elper/include_jni \$(cat out/target/product/hikey/obj/EXECUTABLES/optee_example_secure_storage_intermediates/import_includes)  -I system/core/include -I system/media
/audio/include -I hardware/libhardware/include -I hardware/libhardware_legacy/include -I hardware/ril/include -I libnativehelper/include -I frameworks/native/include
 -I frameworks/native/opengl/include -I frameworks/av/include -isystem device/linaro/hikey/kernel-headers -isystem bionic/libc/include -isystem bionic/libc/kernel/ua
pi -isystem bionic/libc/kernel/uapi/asm-arm64 -isystem bionic/libc/kernel/android/scsi -isystem bionic/libc/kernel/android/uapi -c  -Werror=implicit-function-declara
tion -DANDROID-fmessage-length=0 -W -Wall -Wno-unused -Winit-self -Wpointer-arith -no-canonical-prefixes -DNDEBUG -UDEBUG -fno-exceptions -Wno-multichar -O2 -g -fno-
strict-aliasing -fdebug-prefix-map=/proc/self/cwd= -D__compiler_offsetof=__builtin_offsetof -Werror=int-conversion -Wno-reserved-id-macro -Wno-format-pedantic -Wno-u
nused-command-line-argument -fcolor-diagnostics -Wno-expansion-to-defined -Wno-zero-as-null-pointer-constant -fdebug-prefix-map=\$PWD/= -ffunction-sections -fdata-se
ctions -fno-short-enums -funwind-tables -fstack-protector-strong -Wa,--noexecstack -D_FORTIFY_SOURCE=2 -Wstrict-aliasing=2 -Werror=return-type -Werror=non-virtual-dt
or -Werror=address -Werror=sequence-point -Werror=date-time -Werror=format-security -nostdlibinc -march=armv8-a -mcpu=cortex-a53 -target aarch64-linux-android -Bpreb
uilts/gcc/linux-x86/aarch64/aarch64-linux-android-4.9/aarch64-linux-android/bin   -std=gnu99    -Wall -Werror -DANDROID_BUILD -Wall -fPIE -D_USING_LIBCXX   -Werror=i
nt-to-pointer-cast -Werror=pointer-to-int-cast -Werror=address-of-temporary -Werror=return-type -Wno-tautological-constant-compare -Wno-null-pointer-arithmetic -Wno-
enum-compare -Wno-enum-compare-switch -MD -MF out/target/product/hikey/obj/EXECUTABLES/optee_example_secure_storage_intermediates/host/main.d -o out/target/product/h
ikey/obj/EXECUTABLES/optee_example_secure_storage_intermediates/host/main.o external/optee_examples/secure_storage/host/main.c"
external/optee_examples/secure_storage/host/main.c:169:14: error: unused parameter 'argc' [-Werror,-Wunused-parameter]
int main(int argc, char *argv[])                                                                                               
             ^                                                                                                                 
external/optee_examples/secure_storage/host/main.c:169:26: error: unused parameter 'argv' [-Werror,-Wunused-parameter]
int main(int argc, char *argv[])                                                                                                                        
                         ^                                
2 errors generated.                                                                                                             
[ 23% 3/13] target  C: optee_example_hello_world <= external/optee_examples/hello_world/host/main.c                                                     
ninja: build stopped: subcommand failed.                             
11:03:27 ninja failed with: exit status 1
```