### PR TITLE
sstorage: Add missed header

### DIFF
--- a/secure_storage/ta/secure_storage_ta.c
+++ b/secure_storage/ta/secure_storage_ta.c
@@ -25,6 +25,7 @@
  * POSSIBILITY OF SUCH DAMAGE.
  */
 
+#include <inttypes.h>
 #include <secure_storage_ta.h>
 #include <tee_internal_api.h>
 #include <tee_internal_api_extensions.h>


### PR DESCRIPTION
PRI macro requires inttypes.h header

Signed-off-by: Ruslan Piasetskyi <ruslan.piasetskyi@gmail.com>

```
  CC      /optee/obj/TA_OBJ/f4e750bb-1437-4fbf-8785-8d3580c34994_OBJ/secure_storage_ta.o
In file included from /optee/obj/OPTEE_OBJ/export-ta_arm64/include/tee_api.h:38:0,
                 from /optee/obj/OPTEE_OBJ/export-ta_arm64/include/tee_internal_api.h:33,
                 from secure_storage_ta.c:29:
secure_storage_ta.c: In function ‘read_raw_object’:
secure_storage_ta.c:205:51: error: expected ‘)’ before ‘PRIu32’
   EMSG("TEE_ReadObjectData failed 0x%08x, read %" PRIu32 " over %u",
                                                   ^
/optee/obj/OPTEE_OBJ/export-ta_arm64/include/trace.h:59:8: note: in definition of macro ‘trace_printf_helper’
        __VA_ARGS__)
        ^~~~~~~~~~~
secure_storage_ta.c:205:3: note: in expansion of macro ‘EMSG’
   EMSG("TEE_ReadObjectData failed 0x%08x, read %" PRIu32 " over %u",
   ^~~~
secure_storage_ta.c:205:8: error: format ‘%x’ expects a matching ‘unsigned int’ argument [-Werror=format=]
   EMSG("TEE_ReadObjectData failed 0x%08x, read %" PRIu32 " over %u",
        ^
/optee/obj/OPTEE_OBJ/export-ta_arm64/include/trace.h:59:8: note: in definition of macro ‘trace_printf_helper’
        __VA_ARGS__)
        ^~~~~~~~~~~
secure_storage_ta.c:205:3: note: in expansion of macro ‘EMSG’
   EMSG("TEE_ReadObjectData failed 0x%08x, read %" PRIu32 " over %u",
   ^~~~
secure_storage_ta.c:205:8: error: spurious trailing ‘%’ in format [-Werror=format=]
   EMSG("TEE_ReadObjectData failed 0x%08x, read %" PRIu32 " over %u",
        ^
/optee/obj/OPTEE_OBJ/export-ta_arm64/include/trace.h:59:8: note: in definition of macro ‘trace_printf_helper’
        __VA_ARGS__)
        ^~~~~~~~~~~
secure_storage_ta.c:205:3: note: in expansion of macro ‘EMSG’
   EMSG("TEE_ReadObjectData failed 0x%08x, read %" PRIu32 " over %u",
   ^~~~
cc1: all warnings being treated as errors
```
