### PR TITLE
acipher: add missed header

### DIFF
--- a/acipher/host/main.c
+++ b/acipher/host/main.c
@@ -5,6 +5,7 @@
 
 #include <err.h>
 #include <inttypes.h>
+#include <limits.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>


### PR DESCRIPTION
LONG_MAX is defined in limits.h header

  optee_examples/acipher/host/main.c:46:22: error:
  use of undeclared identifier 'LONG_MAX'