### PR TITLE
acipher: fix TA_FLAGS to be compatible with old version of optee_os

### DIFF
--- a/acipher/ta/user_ta_header_defines.h
+++ b/acipher/ta/user_ta_header_defines.h
@@ -14,7 +14,7 @@
 
 #define TA_UUID				TA_ACIPHER_UUID
 
-#define TA_FLAGS			0
+#define TA_FLAGS			TA_FLAG_EXEC_DDR
 #define TA_STACK_SIZE			(2 * 1024)
 #define TA_DATA_SIZE			(32 * 1024)
 


### PR DESCRIPTION
With optee_os 3.0.0 and below, optee_example_acipher is failed with
the following error:

  optee_example_acipher: TEEC_OpenSession(TEEC_LOGIN_PUBLIC):
  0xffff0005 (error origin 0x3)

TA_FLAG_EXEC_DDR is deprecated but it is necessary to be executed with
optee_os <= 3.0.0.