### PR TITLE
github: update the link to optee_examples documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,4 +8,4 @@ information that used to be here in this git can be found under
 
 // OP-TEE core maintainers
 
-[optee_examples]: https://optee.readthedocs.io/building/gits/optee_examples/optee_examples.html
+[optee_examples]: https://optee.readthedocs.io/en/latest/building/gits/optee_examples/optee_examples.html


### PR DESCRIPTION
This fixes a broken link.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>