### PR TITLE
hotp: fix buffer overflow issue

### DIFF
--- a/hotp/ta/hotp_ta.c
+++ b/hotp/ta/hotp_ta.c
@@ -140,6 +140,9 @@ static TEE_Result register_shared_key(uint32_t param_types, TEE_Param params[4])
 		return TEE_ERROR_BAD_PARAMETERS;
 	}
 
+	if (params[0].memref.size > sizeof(K))
+		return TEE_ERROR_BAD_PARAMETERS;
+
 	memset(K, 0, sizeof(K));
 	memcpy(K, params[0].memref.buffer, params[0].memref.size);
 


### PR DESCRIPTION
The size for the key to register, provided by non-secure world is never
checked, hence it's possible to do an buffer overflow attack in the
HOTP TA. Add a check to control that the size provided isn't greater
that sizeof(K) fixes the issue.

Signed-off-by: Joakim Bech <joakim.bech@linaro.org>
Reported-by: Ronan Loftus <loftus@riscure.com>