### PR TITLE
fix typo in comments for acipher, aes, hello_world and random examples

### DIFF
--- a/acipher/host/main.c
+++ b/acipher/host/main.c
@@ -13,7 +13,7 @@
 /* OP-TEE TEE client API (built by optee_client) */
 #include <tee_client_api.h>
 
-/* To the the UUID (found the the TA's h-file(s)) */
+/* For the UUID (found in the TA's h-file(s)) */
 #include <acipher_ta.h>
 
 static void usage(int argc, char *argv[])

--- a/aes/host/main.c
+++ b/aes/host/main.c
@@ -32,7 +32,7 @@
 /* OP-TEE TEE client API (built by optee_client) */
 #include <tee_client_api.h>
 
-/* To the the UUID (found the the TA's h-file(s)) */
+/* For the UUID (found in the TA's h-file(s)) */
 #include <aes_ta.h>
 
 #define AES_TEST_BUFFER_SIZE	4096

--- a/hello_world/host/main.c
+++ b/hello_world/host/main.c
@@ -32,7 +32,7 @@
 /* OP-TEE TEE client API (built by optee_client) */
 #include <tee_client_api.h>
 
-/* To the the UUID (found the the TA's h-file(s)) */
+/* For the UUID (found in the TA's h-file(s)) */
 #include <hello_world_ta.h>
 
 int main(void)

--- a/random/host/main.c
+++ b/random/host/main.c
@@ -32,7 +32,7 @@
 /* OP-TEE TEE client API (built by optee_client) */
 #include <tee_client_api.h>
 
-/* To the the UUID (found the the TA's h-file(s)) */
+/* For the UUID (found in the TA's h-file(s)) */
 #include <random_ta.h>
 
 int main(void)


### PR DESCRIPTION
Signed-off-by: Aleksandr Anisimov <a.anisimov@omprussia.ru>