### PR TITLE
Makefile: shell fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,12 +12,12 @@ clean: examples-clean prepare-for-rootfs-clean
 
 examples:
 	@for example in $(EXAMPLE_LIST); do \
-		$(MAKE) -C $$example CROSS_COMPILE="$(HOST_CROSS_COMPILE)" || exit -1; \
+		$(MAKE) -C $$example CROSS_COMPILE="$(HOST_CROSS_COMPILE)" || exit 1; \
 	done
 
 examples-clean:
 	@for example in $(EXAMPLE_LIST); do \
-		$(MAKE) -C $$example clean || exit -1; \
+		$(MAKE) -C $$example clean || exit 1; \
 	done
 
 prepare-for-rootfs: examples


### PR DESCRIPTION
"exit -1" has traditionally had "exit 255" result, but starts to be
rejected by some shells (eg. dash, which is is the default on many
Debian systems):

 host$ bash
 $ exit -1
 exit
 host$ echo $?
 255

 host$ dash
 $ exit -1
 dash: 1: exit: Illegal number: -1
 $
 host$ echo $?
 2

Signed-off-by: Yann Dirson <yann@blade-group.com>