### PR TITLE
Use LDFLAGS for host binaries

### DIFF
--- a/acipher/host/Makefile
+++ b/acipher/host/Makefile
@@ -18,7 +18,7 @@ BINARY = optee_example_acipher
 all: $(BINARY)
 
 $(BINARY): $(OBJS)
-	$(CC) -o $@ $< $(LDADD)
+	$(CC) $(LDFLAGS) -o $@ $< $(LDADD)
 
 .PHONY: clean
 clean:

--- a/aes/host/Makefile
+++ b/aes/host/Makefile
@@ -18,7 +18,7 @@ BINARY = optee_example_aes
 all: $(BINARY)
 
 $(BINARY): $(OBJS)
-	$(CC) -o $@ $< $(LDADD)
+	$(CC) $(LDFLAGS) -o $@ $< $(LDADD)
 
 .PHONY: clean
 clean:

--- a/hello_world/host/Makefile
+++ b/hello_world/host/Makefile
@@ -18,7 +18,7 @@ BINARY = optee_example_hello_world
 all: $(BINARY)
 
 $(BINARY): $(OBJS)
-	$(CC) -o $@ $< $(LDADD)
+	$(CC) $(LDFLAGS) -o $@ $< $(LDADD)
 
 .PHONY: clean
 clean:

--- a/hotp/host/Makefile
+++ b/hotp/host/Makefile
@@ -18,7 +18,7 @@ BINARY = optee_example_hotp
 all: $(BINARY)
 
 $(BINARY): $(OBJS)
-	$(CC) -o $@ $< $(LDADD)
+	$(CC) $(LDFLAGS) -o $@ $< $(LDADD)
 
 .PHONY: clean
 clean:

--- a/random/host/Makefile
+++ b/random/host/Makefile
@@ -18,7 +18,7 @@ BINARY = optee_example_random
 all: $(BINARY)
 
 $(BINARY): $(OBJS)
-	$(CC) -o $@ $< $(LDADD)
+	$(CC) $(LDFLAGS) -o $@ $< $(LDADD)
 
 .PHONY: clean
 clean:

--- a/secure_storage/host/Makefile
+++ b/secure_storage/host/Makefile
@@ -18,7 +18,7 @@ BINARY = optee_example_secure_storage
 all: $(BINARY)
 
 $(BINARY): $(OBJS)
-	$(CC) -o $@ $< $(LDADD)
+	$(CC) $(LDFLAGS) -o $@ $< $(LDADD)
 
 .PHONY: clean
 clean:


### PR DESCRIPTION
Distributions bring their own sets of LDFLAGS, and some fail when
binaries do not match their expectation after ignoring those flags.

Eg. for yocto:

 ERROR: optee-examples-3.12.0+gitAUTOINC+9a755dcf4d-r0 do_package_qa: QA Issue: File /usr/bin/optee_example_secure_storage in package optee-examples doesn't have GNU_HASH (didn't pass LDFLAGS?)
 File /usr/bin/optee_example_acipher in package optee-examples doesn't have GNU_HASH (didn't pass LDFLAGS?)
 ...

Signed-off-by: Yann Dirson <yann@blade-group.com>