### PR TITLE
plugins: fix formatting string of the syslog()

### DIFF
--- a/plugins/syslog/syslog_plugin.c
+++ b/plugins/syslog/syslog_plugin.c
@@ -25,7 +25,7 @@ static TEEC_Result write_syslog(unsigned int sub_cmd, void *data, size_t data_le
 {
 	/* 'sub_cmd' in this case means priority according syslog.h */
 	openlog(NULL, LOG_CONS | LOG_PID, LOG_DAEMON);
-	syslog(sub_cmd, "%*s", (int)data_len, (const char *)data);
+	syslog(sub_cmd, "%.*s", (int)data_len, (const char *)data);
 	closelog();
 
 	return TEEC_SUCCESS;


### PR DESCRIPTION
There is a over-print in current version of `syslog_plugin.c`, since `(const char*) data` is not NULL terminated.
```
# optee_example_plugins 
Work logic: REE --> plugin TA --> syslog plugin in REE --> syslog
See the log from TEE through 'journalctl'

Attempt #1: TEEC_InvokeCommand() success; res=0 orig=0x4
Attempt #2: TEEC_InvokeCommand() success; res=0 orig=0x4
Attempt #3: TEEC_InvokeCommand() success; res=0 orig=0x4
Attempt #4: TEEC_InvokeCommand() success; res=0 orig=0x4
Attempt #5: TEEC_InvokeCommand() success; res=0 orig=0x4
# tail -f /var/log/messages 
Apr 29 00:53:16 buildroot daemon.info tee-supplicant[137]: Hello, plugin! value = 0x0^RX_^H~^B
Apr 29 00:53:18 buildroot daemon.info tee-supplicant[137]: Hello, plugin! value = 0x1
Apr 29 00:53:20 buildroot daemon.info tee-supplicant[137]: Hello, plugin! value = 0x2y0^Y7m^U^A
Apr 29 00:53:22 buildroot daemon.info tee-supplicant[137]: Hello, plugin! value = 0x3
Apr 29 00:53:24 buildroot daemon.info tee-supplicant[137]: Hello, plugin! value = 0x4^Mji*
```

https://www.cplusplus.com/reference/cstdio/printf/
> .number:
>
> For s: this is the maximum number of characters to be printed. By default all characters are printed until the ending null character is encountered.

Can be fixed by replace `%*s` with `%.*s` :)

```
# optee_example_plugins 
Work logic: REE --> plugin TA --> syslog plugin in REE --> syslog
See the log from TEE through 'journalctl'

Attempt #1: TEEC_InvokeCommand() success; res=0 orig=0x4
Attempt #2: TEEC_InvokeCommand() success; res=0 orig=0x4
Attempt #3: TEEC_InvokeCommand() success; res=0 orig=0x4
Attempt #4: TEEC_InvokeCommand() success; res=0 orig=0x4
Attempt #5: TEEC_InvokeCommand() success; res=0 orig=0x4
# tail -f /var/log/messages 
Apr 29 01:54:07 buildroot daemon.info tee-supplicant[138]: Hello, plugin! value = 0x0
Apr 29 01:54:09 buildroot daemon.info tee-supplicant[138]: Hello, plugin! value = 0x1
Apr 29 01:54:11 buildroot daemon.info tee-supplicant[138]: Hello, plugin! value = 0x2
Apr 29 01:54:13 buildroot daemon.info tee-supplicant[138]: Hello, plugin! value = 0x3
Apr 29 01:54:15 buildroot daemon.info tee-supplicant[138]: Hello, plugin! value = 0x4
```

