### PR TITLE
Makefile: Fix non-portable sh check for plugins

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ prepare-for-rootfs: examples
 			cp -p $$example/host/optee_example_$$example $(OUTPUT_DIR)/ca/; \
 		fi; \
 		cp -pr $$example/ta/*.ta $(OUTPUT_DIR)/ta/; \
-		if [ $$example == plugins ]; then \
+		if [ $$example = plugins ]; then \
 			cp -p plugins/syslog/*.plugin $(OUTPUT_DIR)/plugins/; \
 		fi; \
 	done


### PR DESCRIPTION
Comparison with "==" is non-portable, resulting in an error:

/bin/sh: 6: [: acipher: unexpected operator
/bin/sh: 6: [: plugins: unexpected operator
/bin/sh: 6: [: hello_world: unexpected operator
/bin/sh: 6: [: hotp: unexpected operator
/bin/sh: 6: [: aes: unexpected operator
/bin/sh: 6: [: random: unexpected operator
/bin/sh: 6: [: secure_storage: unexpected operator

if /bin/sh doesnt point to bash.

Signed-off-by: Alejandro Enedino Hernandez Samaniego <alhe@linux.microsoft.com>
Signed-off-by: Ricardo Salveti <ricardo@foundries.io>