### PR TITLE
pluging: add missing of dependency syslog on teec

### DIFF
--- a/plugins/syslog/CMakeLists.txt
+++ b/plugins/syslog/CMakeLists.txt
@@ -5,4 +5,6 @@ set (CMAKE_SHARED_LIBRARY_PREFIX "")
 
 add_library(${PROJECT_NAME} SHARED syslog_plugin.c)
 
+target_link_libraries (${PROJECT_NAME} PRIVATE teec)
+
 install (TARGETS ${PROJECT_NAME} DESTINATION ${CFG_TEE_PLUGIN_LOAD_PATH})


### PR DESCRIPTION
Adds missing dependency of plugins/syslog example on libteec header files that are brought in by libteec. The issue was reported by compiler with the below build error message:

/tmp/optee/optee_examples/plugins/syslog/syslog_plugin.c:8:10: fatal error: tee_plugin_method.h: No such file or directory
    8 | #include <tee_plugin_method.h>
      |          ^~~~~~~~~~~~~~~~~~~~~

Signed-off-by: Etienne Carriere <etienne.carriere@linaro.org>