### PR TITLE
Remove misleading TA properties in new added examples

### DIFF
--- a/acipher/ta/user_ta_header_defines.h
+++ b/acipher/ta/user_ta_header_defines.h
@@ -15,12 +15,17 @@
 #define TA_UUID				TA_ACIPHER_UUID
 
 #define TA_FLAGS			TA_FLAG_EXEC_DDR
+
+/* Provisioned stack size */
 #define TA_STACK_SIZE			(2 * 1024)
+
+/* Provisioned heap size for TEE_Malloc() and friends */
 #define TA_DATA_SIZE			(32 * 1024)
 
-#define TA_CURRENT_TA_EXT_PROPERTIES \
-    { "gp.ta.description", USER_TA_PROP_TYPE_STRING, \
-        "Example of TA using asymmetric cipher" }, \
-    { "gp.ta.version", USER_TA_PROP_TYPE_U32, &(const uint32_t){ 0x0010 } }
+/* The gpd.ta.version property */
+#define TA_VERSION	"1.0"
+
+/* The gpd.ta.description property */
+#define TA_DESCRIPTION	"Example of TA using asymmetric cipher"
 
 #endif /*USER_TA_HEADER_DEFINES_H*/

--- a/aes/ta/user_ta_header_defines.h
+++ b/aes/ta/user_ta_header_defines.h
@@ -37,12 +37,17 @@
 #define TA_UUID				TA_AES_UUID
 
 #define TA_FLAGS			TA_FLAG_EXEC_DDR
+
+/* Provisioned stack size */
 #define TA_STACK_SIZE			(2 * 1024)
+
+/* Provisioned heap size for TEE_Malloc() and friends */
 #define TA_DATA_SIZE			(32 * 1024)
 
-#define TA_CURRENT_TA_EXT_PROPERTIES \
-    { "gp.ta.description", USER_TA_PROP_TYPE_STRING, \
-        "Example of TA using an AES sequence" }, \
-    { "gp.ta.version", USER_TA_PROP_TYPE_U32, &(const uint32_t){ 0x0010 } }
+/* The gpd.ta.version property */
+#define TA_VERSION	"1.0"
+
+/* The gpd.ta.description property */
+#define TA_DESCRIPTION	"Example of TA using an AES sequence"
 
 #endif /*USER_TA_HEADER_DEFINES_H*/

--- a/secure_storage/ta/user_ta_header_defines.h
+++ b/secure_storage/ta/user_ta_header_defines.h
@@ -37,12 +37,17 @@
 #define TA_UUID				TA_SECURE_STORAGE_UUID
 
 #define TA_FLAGS			(TA_FLAG_EXEC_DDR | TA_FLAG_SINGLE_INSTANCE)
+
+/* Provisioned heap size for TEE_Malloc() and friends */
 #define TA_STACK_SIZE			(2 * 1024)
+
+/* Provisioned heap size for TEE_Malloc() and friends */
 #define TA_DATA_SIZE			(32 * 1024)
 
-#define TA_CURRENT_TA_EXT_PROPERTIES \
-    { "gp.ta.description", USER_TA_PROP_TYPE_STRING, \
-        "Example of TA writing/reading data from its secure storage" }, \
-    { "gp.ta.version", USER_TA_PROP_TYPE_U32, &(const uint32_t){ 0x0010 } }
+/* The gpd.ta.version property */
+#define TA_VERSION	"1.0"
+
+/* The gpd.ta.description property */
+#define TA_DESCRIPTION	"Example of TA writing/reading data from its secure storage"
 
 #endif /*USER_TA_HEADER_DEFINES_H*/


### PR DESCRIPTION
This relates to #119 