### PR TITLE
sign_verify: Add dynamic algorithm selection with sign and verify sup…

### DIFF
--- a/sign_verify/Android.mk
+++ b/sign_verify/Android.mk
@@ -1,0 +1,17 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+LOCAL_CFLAGS += -DANDROID_BUILD
+LOCAL_CFLAGS += -Wall
+
+LOCAL_SRC_FILES += host/main.c
+
+LOCAL_C_INCLUDES := $(LOCAL_PATH)/ta/include
+
+LOCAL_SHARED_LIBRARIES := libteec
+LOCAL_MODULE := optee_example_sign_verify
+LOCAL_VENDOR_MODULE := true
+LOCAL_MODULE_TAGS := optional
+include $(BUILD_EXECUTABLE)
+
+include $(LOCAL_PATH)/ta/Android.mk

--- a/sign_verify/CMakeLists.txt
+++ b/sign_verify/CMakeLists.txt
@@ -1,0 +1,13 @@
+project (optee_example_sign_verify C)
+
+set (SRC host/main.c)
+
+add_executable (${PROJECT_NAME} ${SRC})
+
+target_include_directories(${PROJECT_NAME}
+			   PRIVATE ta/include
+			   PRIVATE include)
+
+target_link_libraries (${PROJECT_NAME} PRIVATE teec)
+
+install (TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/sign_verify/Makefile
+++ b/sign_verify/Makefile
@@ -1,0 +1,15 @@
+export V ?= 0
+
+# If _HOST or _TA specific compilers are not specified, then use CROSS_COMPILE
+HOST_CROSS_COMPILE ?= $(CROSS_COMPILE)
+TA_CROSS_COMPILE ?= $(CROSS_COMPILE)
+
+.PHONY: all
+all:
+	$(MAKE) -C host CROSS_COMPILE="$(HOST_CROSS_COMPILE)" --no-builtin-variables
+	$(MAKE) -C ta CROSS_COMPILE="$(TA_CROSS_COMPILE)" LDFLAGS=""
+
+.PHONY: clean
+clean:
+	$(MAKE) -C host clean
+	$(MAKE) -C ta clean

--- a/sign_verify/host/Makefile
+++ b/sign_verify/host/Makefile
@@ -1,0 +1,28 @@
+CC      ?= $(CROSS_COMPILE)gcc
+LD      ?= $(CROSS_COMPILE)ld
+AR      ?= $(CROSS_COMPILE)ar
+NM      ?= $(CROSS_COMPILE)nm
+OBJCOPY ?= $(CROSS_COMPILE)objcopy
+OBJDUMP ?= $(CROSS_COMPILE)objdump
+READELF ?= $(CROSS_COMPILE)readelf
+
+OBJS = main.o
+
+CFLAGS += -Wall -I../ta/include -I./include
+CFLAGS += -I$(TEEC_EXPORT)/include
+LDADD += -lteec -L$(TEEC_EXPORT)/lib
+
+BINARY = optee_example_sign_verify
+
+.PHONY: all
+all: $(BINARY)
+
+$(BINARY): $(OBJS)
+	$(CC) $(LDFLAGS) -o $@ $< $(LDADD)
+
+.PHONY: clean
+clean:
+	rm -f $(OBJS) $(BINARY)
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@

--- a/sign_verify/host/main.c
+++ b/sign_verify/host/main.c
@@ -1,0 +1,156 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+ */
+
+#include <err.h>
+#include <stdio.h>
+#include <string.h>
+#include <inttypes.h>
+#include <limits.h>
+#include <stdlib.h>
+
+#include <tee_client_api.h>
+#include <sign_verify_ta.h>
+
+static void usage(int argc, char *argv[])
+{
+	printf("%s: optee_example_sign_verify <key_size> <algo_name>\n",
+	       __func__);
+	printf("<key_size>:  key size in bits. Supported values are: ");
+	printf("2048 bits (default), 3072 bits and 4096 bits\n");
+
+	printf("<algo_name>: algorithm name. Supported values are:\n");
+	printf("TA_ALG_PKCS1_V1_5_SHA1\n");
+	printf("TA_ALG_PKCS1_V1_5_SHA224\n");
+	printf("TA_ALG_PKCS1_V1_5_SHA256 (default)\n");
+	printf("TA_ALG_PKCS1_V1_5_SHA384\n");
+	printf("TA_ALG_PKCS1_V1_5_SHA512\n");
+	printf("TA_ALG_PKCS1_PSS_MGF1_SHA1\n");
+	printf("TA_ALG_PKCS1_PSS_MGF1_SHA224\n");
+	printf("TA_ALG_PKCS1_PSS_MGF1_SHA256\n");
+	printf("TA_ALG_PKCS1_PSS_MGF1_SHA384\n");
+	printf("TA_ALG_PKCS1_PSS_MGF1_SHA512\n");
+
+	exit(1);
+}
+
+static void get_args(int argc, char *argv[], size_t *key_size,
+		     uint32_t *selected_alg)
+{
+	char *ep;
+	long ks = 2048;
+	char *algo;
+
+	if (argc > 3)
+		usage(argc, argv);
+
+	if (argc > 1) {
+		ks = strtol(argv[1], &ep, 0);
+		if (*ep) {
+			warnx("cannot parse key_size \"%s\"", argv[1]);
+			usage(argc, argv);
+		}
+	}
+
+	if (ks < 0 || ks == LONG_MAX) {
+		warnx("bad key_size \"%s\" (%ld)", argv[1], ks);
+		usage(argc, argv);
+	}
+
+	*key_size = ks;
+	printf("Key size: %lu\n", *key_size);
+
+	if (argc > 2) {
+		algo = argv[2];
+		printf("%s algo selected\n", algo);
+		if (strcmp(algo, "TA_ALG_PKCS1_V1_5_SHA1") == 0) {
+			*selected_alg = TA_ALG_PKCS1_V1_5_SHA1;
+		} else if (strcmp(algo, "TA_ALG_PKCS1_V1_5_SHA224") == 0) {
+			*selected_alg = TA_ALG_PKCS1_V1_5_SHA224;
+		} else if (strcmp(algo, "TA_ALG_PKCS1_V1_5_SHA256") == 0) {
+			*selected_alg = TA_ALG_PKCS1_V1_5_SHA256;
+		} else if (strcmp(algo, "TA_ALG_PKCS1_V1_5_SHA384") == 0) {
+			*selected_alg = TA_ALG_PKCS1_V1_5_SHA384;
+		} else if (strcmp(algo, "TA_ALG_PKCS1_V1_5_SHA512") == 0) {
+			*selected_alg = TA_ALG_PKCS1_V1_5_SHA512;
+		} else if (strcmp(algo, "TA_ALG_PKCS1_PSS_MGF1_SHA1") == 0) {
+			*selected_alg = TA_ALG_PKCS1_PSS_MGF1_SHA1;
+		} else if (strcmp(algo, "TA_ALG_PKCS1_PSS_MGF1_SHA224") == 0) {
+			*selected_alg = TA_ALG_PKCS1_PSS_MGF1_SHA224;
+		} else if (strcmp(algo, "TA_ALG_PKCS1_PSS_MGF1_SHA256") == 0) {
+			*selected_alg = TA_ALG_PKCS1_PSS_MGF1_SHA256;
+		} else if (strcmp(algo, "TA_ALG_PKCS1_PSS_MGF1_SHA384") == 0) {
+			*selected_alg = TA_ALG_PKCS1_PSS_MGF1_SHA384;
+		} else if (strcmp(algo, "TA_ALG_PKCS1_PSS_MGF1_SHA512") == 0) {
+			*selected_alg = TA_ALG_PKCS1_PSS_MGF1_SHA512;
+		} else {
+			printf("%s algo is invalid\n", algo);
+			usage(argc, argv);
+		}
+	} else {
+		printf("TA_ALG_PKCS1_V1_5_SHA256 algo selected\n");
+		*selected_alg = TA_ALG_PKCS1_V1_5_SHA256;
+	}
+
+}
+
+int main(int argc, char *argv[])
+{
+	TEEC_Result res;
+	TEEC_Context ctx;
+	TEEC_Session sess;
+	TEEC_Operation op;
+	TEEC_UUID uuid = TA_SIGN_VERIFY_UUID;
+	uint32_t origin;
+	char message[] = "HelloFromHost";
+	uint8_t signature[MAX_SIG_SIZE];
+	size_t sig_len = sizeof(signature);
+	uint32_t selected_alg;
+	size_t key_size;
+
+	get_args(argc, argv, &key_size, &selected_alg);
+
+	printf("Prepare session with the TA\n");
+	res = TEEC_InitializeContext(NULL, &ctx);
+	if (res != TEEC_SUCCESS)
+		errx(1, "TEEC_InitializeContext failed: 0x%x", res);
+
+	res = TEEC_OpenSession(&ctx, &sess, &uuid, TEEC_LOGIN_PUBLIC, NULL,
+			       NULL, &origin);
+	if (res != TEEC_SUCCESS)
+		errx(1, "TEEC_OpenSession failed: 0x%x origin: 0x%x", res,
+		     origin);
+
+	memset(&op, 0, sizeof(op));
+	op.paramTypes = TEEC_PARAM_TYPES(TEEC_MEMREF_TEMP_INPUT,
+					 TEEC_MEMREF_TEMP_OUTPUT,
+					 TEEC_VALUE_INPUT,
+					 TEEC_VALUE_INPUT);
+	op.params[0].tmpref.buffer = message;
+	op.params[0].tmpref.size = strlen(message);
+	op.params[1].tmpref.buffer = signature;
+	op.params[1].tmpref.size = (uint32_t)sig_len;
+	op.params[2].value.a = selected_alg;
+	op.params[3].value.a = key_size;
+
+	printf("Prepare sign and verify operations\n");
+	res = TEEC_InvokeCommand(&sess, TA_RSA_SIGN_CMD_SIGN_VERIFY, &op,
+				 &origin);
+	if (res != TEEC_SUCCESS)
+		errx(1, "TEEC_InvokeCommand failed: 0x%x origin: 0x%x", res,
+		     origin);
+	printf("Sign and verify successful. Signature length: %zu bytes\n",
+	       op.params[1].tmpref.size);
+
+	printf("Signature: ");
+	for (size_t i = 0; i < op.params[1].tmpref.size; i++)
+		printf("%02x ", signature[i]);
+
+	printf("\n");
+
+	TEEC_CloseSession(&sess);
+	TEEC_FinalizeContext(&ctx);
+
+	return 0;
+}

--- a/sign_verify/ta/Android.mk
+++ b/sign_verify/ta/Android.mk
@@ -1,0 +1,4 @@
+LOCAL_PATH := $(call my-dir)
+
+local_module := f066f150-42af-404f-ae32-c8e6cd117e70.ta
+include $(BUILD_OPTEE_MK)

--- a/sign_verify/ta/Makefile
+++ b/sign_verify/ta/Makefile
@@ -1,0 +1,13 @@
+CFG_TEE_TA_LOG_LEVEL ?= 4
+CFG_TA_OPTEE_CORE_API_COMPAT_1_1=y
+
+# The UUID for the Trusted Application
+BINARY=f066f150-42af-404f-ae32-c8e6cd117e70
+
+-include $(TA_DEV_KIT_DIR)/mk/ta_dev_kit.mk
+
+ifeq ($(wildcard $(TA_DEV_KIT_DIR)/mk/ta_dev_kit.mk), )
+clean:
+	@echo 'Note: $$(TA_DEV_KIT_DIR)/mk/ta_dev_kit.mk not found, cannot clean TA'
+	@echo 'Note: TA_DEV_KIT_DIR=$(TA_DEV_KIT_DIR)'
+endif

--- a/sign_verify/ta/include/sign_verify_ta.h
+++ b/sign_verify/ta/include/sign_verify_ta.h
@@ -1,0 +1,30 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+ */
+
+#ifndef __SIGN_VERIFY_TA_H__
+#define __SIGN_VERIFY_TA_H__
+
+/* UUID of the AES example trusted application */
+#define TA_SIGN_VERIFY_UUID \
+	{ 0xf066f150, 0x42af, 0x404f, \
+		{ 0xae, 0x32, 0xc8, 0xe6, 0xcd, 0x11, 0x7e, 0x70 } }
+
+#define TA_RSA_SIGN_CMD_SIGN_VERIFY	0
+
+#define TA_ALG_PKCS1_PSS_MGF1_SHA1	0
+#define TA_ALG_PKCS1_PSS_MGF1_SHA224	1
+#define TA_ALG_PKCS1_PSS_MGF1_SHA256	2
+#define TA_ALG_PKCS1_PSS_MGF1_SHA384	3
+#define TA_ALG_PKCS1_PSS_MGF1_SHA512	4
+
+#define TA_ALG_PKCS1_V1_5_SHA1		5
+#define TA_ALG_PKCS1_V1_5_SHA224	6
+#define TA_ALG_PKCS1_V1_5_SHA256	7
+#define TA_ALG_PKCS1_V1_5_SHA384	8
+#define TA_ALG_PKCS1_V1_5_SHA512	9
+
+#define MAX_SIG_SIZE			512
+
+#endif

--- a/sign_verify/ta/sign_verify_ta.c
+++ b/sign_verify/ta/sign_verify_ta.c
@@ -1,0 +1,259 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+ */
+
+
+#include <tee_internal_api.h>
+#include <tee_internal_api_extensions.h>
+#include <string.h>
+#include <sign_verify_ta.h>
+
+struct rsa_session {
+	TEE_ObjectHandle keypair;
+	TEE_ObjectHandle public_key;
+};
+
+TEE_Result TA_CreateEntryPoint(void)
+{
+	return TEE_SUCCESS;
+}
+
+void TA_DestroyEntryPoint(void)
+{
+}
+
+static TEE_Result generate_rsa_keys(struct rsa_session *sess, size_t key_sz)
+{
+	TEE_Result res;
+
+	res = TEE_AllocateTransientObject(TEE_TYPE_RSA_KEYPAIR, key_sz,
+					  &sess->keypair);
+	if (res != TEE_SUCCESS)
+		return res;
+
+	res = TEE_GenerateKey(sess->keypair, key_sz, NULL, 0);
+	if (res != TEE_SUCCESS) {
+		TEE_FreeTransientObject(sess->keypair);
+		return res;
+	}
+
+	res = TEE_AllocateTransientObject(TEE_TYPE_RSA_PUBLIC_KEY, key_sz,
+					  &sess->public_key);
+	if (res != TEE_SUCCESS) {
+		TEE_FreeTransientObject(sess->keypair);
+		return res;
+	}
+
+	res = TEE_CopyObjectAttributes1(sess->public_key, sess->keypair);
+	if (res != TEE_SUCCESS) {
+		TEE_FreeTransientObject(sess->public_key);
+		TEE_FreeTransientObject(sess->keypair);
+		return res;
+	}
+
+	return TEE_SUCCESS;
+}
+
+TEE_Result TA_OpenSessionEntryPoint(uint32_t __unused param_types,
+				    TEE_Param __unused params[4],
+				    void **session_context)
+{
+	struct rsa_session *sess = TEE_Malloc(sizeof(*sess),
+					      TEE_MALLOC_FILL_ZERO);
+
+	if (!sess)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	sess->keypair = TEE_HANDLE_NULL;
+	sess->public_key = TEE_HANDLE_NULL;
+	*session_context = sess;
+	return TEE_SUCCESS;
+}
+
+void TA_CloseSessionEntryPoint(void *session_context)
+{
+	struct rsa_session *sess = (struct rsa_session *)session_context;
+
+	TEE_FreeTransientObject(sess->public_key);
+	TEE_FreeTransientObject(sess->keypair);
+	TEE_Free(sess);
+}
+
+static TEE_Result select_algo(uint32_t sig_alg, uint32_t *algo_num)
+{
+	switch (sig_alg) {
+	case TA_ALG_PKCS1_PSS_MGF1_SHA1:
+		*algo_num = TEE_ALG_RSASSA_PKCS1_PSS_MGF1_SHA1;
+		return TEE_SUCCESS;
+	case TA_ALG_PKCS1_PSS_MGF1_SHA224:
+		*algo_num = TEE_ALG_RSASSA_PKCS1_PSS_MGF1_SHA224;
+		return TEE_SUCCESS;
+	case TA_ALG_PKCS1_PSS_MGF1_SHA256:
+		*algo_num = TEE_ALG_RSASSA_PKCS1_PSS_MGF1_SHA256;
+		return TEE_SUCCESS;
+	case TA_ALG_PKCS1_PSS_MGF1_SHA384:
+		*algo_num = TEE_ALG_RSASSA_PKCS1_PSS_MGF1_SHA384;
+		return TEE_SUCCESS;
+	case TA_ALG_PKCS1_PSS_MGF1_SHA512:
+		*algo_num = TEE_ALG_RSASSA_PKCS1_PSS_MGF1_SHA512;
+		return TEE_SUCCESS;
+	case TA_ALG_PKCS1_V1_5_SHA1:
+		*algo_num = TEE_ALG_RSASSA_PKCS1_V1_5_SHA1;
+		return TEE_SUCCESS;
+	case TA_ALG_PKCS1_V1_5_SHA224:
+		*algo_num = TEE_ALG_RSASSA_PKCS1_V1_5_SHA224;
+		return TEE_SUCCESS;
+	case TA_ALG_PKCS1_V1_5_SHA256:
+		*algo_num = TEE_ALG_RSASSA_PKCS1_V1_5_SHA256;
+		return TEE_SUCCESS;
+	case TA_ALG_PKCS1_V1_5_SHA384:
+		*algo_num = TEE_ALG_RSASSA_PKCS1_V1_5_SHA384;
+		return TEE_SUCCESS;
+	case TA_ALG_PKCS1_V1_5_SHA512:
+		*algo_num = TEE_ALG_RSASSA_PKCS1_V1_5_SHA512;
+		return TEE_SUCCESS;
+	default:
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+}
+
+static uint32_t get_hash_alg_from_sig_alg(uint32_t sig_alg)
+{
+	switch (sig_alg) {
+	case TEE_ALG_RSASSA_PKCS1_V1_5_SHA1:
+	case TEE_ALG_RSASSA_PKCS1_PSS_MGF1_SHA1:
+		return TEE_ALG_SHA1;
+	case TEE_ALG_RSASSA_PKCS1_V1_5_SHA224:
+	case TEE_ALG_RSASSA_PKCS1_PSS_MGF1_SHA224:
+		return TEE_ALG_SHA224;
+	case TEE_ALG_RSASSA_PKCS1_V1_5_SHA256:
+	case TEE_ALG_RSASSA_PKCS1_PSS_MGF1_SHA256:
+		return TEE_ALG_SHA256;
+	case TEE_ALG_RSASSA_PKCS1_V1_5_SHA384:
+	case TEE_ALG_RSASSA_PKCS1_PSS_MGF1_SHA384:
+		return TEE_ALG_SHA384;
+	case TEE_ALG_RSASSA_PKCS1_V1_5_SHA512:
+	case TEE_ALG_RSASSA_PKCS1_PSS_MGF1_SHA512:
+		return TEE_ALG_SHA512;
+	default:
+		return 0;
+	}
+}
+
+static TEE_Result sign_verify(uint32_t param_types,
+			      TEE_Param params[4],
+			      void *session_context)
+{
+
+	struct rsa_session *sess = (struct rsa_session *)session_context;
+
+	uint32_t exp_param_types = TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
+						   TEE_PARAM_TYPE_MEMREF_OUTPUT,
+						   TEE_PARAM_TYPE_VALUE_INPUT,
+						   TEE_PARAM_TYPE_VALUE_INPUT);
+	TEE_Result res;
+	TEE_OperationHandle hash_op = TEE_HANDLE_NULL;
+	TEE_OperationHandle sign_op = TEE_HANDLE_NULL;
+	TEE_OperationHandle verify_op = TEE_HANDLE_NULL;
+	uint8_t digest[64];
+	uint32_t digest_len = sizeof(digest);
+	uint8_t sig[MAX_SIG_SIZE];
+	uint32_t sig_len = sizeof(sig);
+	uint32_t sig_alg;
+	uint32_t algo_num;
+	uint32_t hash_alg;
+
+	if (param_types != exp_param_types)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	sig_alg = params[2].value.a;
+	res = select_algo(sig_alg, &algo_num);
+	if (res != TEE_SUCCESS)
+		return res;
+
+	hash_alg = get_hash_alg_from_sig_alg(algo_num);
+	if (hash_alg == 0)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	void *msg = params[0].memref.buffer;
+	size_t msg_len = params[0].memref.size;
+	void *out = params[1].memref.buffer;
+	size_t out_len = params[1].memref.size;
+	size_t key_sz = params[3].value.a;
+
+	/* Generate Key */
+	DMSG("Generate Key");
+	res = generate_rsa_keys(sess, key_sz);
+	if (res != TEE_SUCCESS) {
+		TEE_Free(sess);
+		return res;
+	}
+
+	/* Compute SHA digest */
+	DMSG("Prepare SHA digest");
+	res = TEE_AllocateOperation(&hash_op, hash_alg, TEE_MODE_DIGEST, 0);
+	if (res != TEE_SUCCESS)
+		goto exit;
+	TEE_DigestUpdate(hash_op, msg, msg_len);
+	res = TEE_DigestDoFinal(hash_op, NULL, 0, digest, &digest_len);
+	if (res != TEE_SUCCESS)
+		goto exit;
+
+	/* Sign the digest */
+	DMSG("Signature on SHA digest");
+	res = TEE_AllocateOperation(&sign_op, algo_num, TEE_MODE_SIGN, key_sz);
+	if (res != TEE_SUCCESS)
+		goto exit;
+	res = TEE_SetOperationKey(sign_op, sess->keypair);
+	if (res != TEE_SUCCESS)
+		goto exit;
+	res = TEE_AsymmetricSignDigest(sign_op, NULL, 0, digest,
+				       digest_len, sig, &sig_len);
+	if (res != TEE_SUCCESS)
+		goto exit;
+
+	/* Verify the signature */
+	DMSG("Verify Signature on SHA digest");
+	res = TEE_AllocateOperation(&verify_op, algo_num, TEE_MODE_VERIFY,
+				    key_sz);
+	if (res != TEE_SUCCESS)
+		goto exit;
+	res = TEE_SetOperationKey(verify_op, sess->public_key);
+	if (res != TEE_SUCCESS)
+		goto exit;
+	res = TEE_AsymmetricVerifyDigest(verify_op, NULL, 0,
+					 digest, digest_len,
+					 sig, sig_len);
+	if (res != TEE_SUCCESS)
+		goto exit;
+
+	if (out_len < sig_len) {
+		params[1].memref.size = sig_len;
+		EMSG("required sig_len = %u", params[1].memref.size);
+		res = TEE_ERROR_SHORT_BUFFER;
+		goto exit;
+	}
+
+	memcpy(out, sig, sig_len);
+	params[1].memref.size = sig_len;
+
+exit:
+	TEE_FreeOperation(verify_op);
+	TEE_FreeOperation(sign_op);
+	TEE_FreeOperation(hash_op);
+	return res;
+}
+
+TEE_Result TA_InvokeCommandEntryPoint(void *session_context,
+				      uint32_t cmd_id,
+				      uint32_t param_types,
+				      TEE_Param params[4])
+{
+	switch (cmd_id) {
+	case TA_RSA_SIGN_CMD_SIGN_VERIFY:
+		return sign_verify(param_types, params, session_context);
+	default:
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+}

--- a/sign_verify/ta/sub.mk
+++ b/sign_verify/ta/sub.mk
@@ -1,0 +1,2 @@
+global-incdirs-y += include
+srcs-y += sign_verify_ta.c

--- a/sign_verify/ta/user_ta_header_defines.h
+++ b/sign_verify/ta/user_ta_header_defines.h
@@ -1,0 +1,28 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+ */
+
+
+#ifndef USER_TA_HEADER_DEFINES_H
+#define USER_TA_HEADER_DEFINES_H
+
+#include <sign_verify_ta.h>
+
+#define TA_UUID				TA_SIGN_VERIFY_UUID
+
+#define TA_FLAGS			TA_FLAG_EXEC_DDR
+
+/* Provisioned stack size */
+#define TA_STACK_SIZE			(2 * 1024)
+
+/* Provisioned heap size for TEE_Malloc() and friends */
+#define TA_DATA_SIZE			(32 * 1024)
+
+/* The gpd.ta.version property */
+#define TA_VERSION	"1.0"
+
+/* The gpd.ta.description property */
+#define TA_DESCRIPTION	"Example of TA using an Sign and Verify sequence"
+
+#endif /*USER_TA_HEADER_DEFINES_H*/


### PR DESCRIPTION
…port

Add support for new RSA PKCS PSS and V1_5 algorithms:
- TEE_ALG_RSASSA_PKCS1_V1_5_SHA1
- TEE_ALG_RSASSA_PKCS1_V1_5_SHA224
- TEE_ALG_RSASSA_PKCS1_V1_5_SHA256
- TEE_ALG_RSASSA_PKCS1_V1_5_SHA384
- TEE_ALG_RSASSA_PKCS1_V1_5_SHA512
- TEE_ALG_RSASSA_PKCS1_PSS_MGF1_SHA1
- TEE_ALG_RSASSA_PKCS1_PSS_MGF1_SHA224
- TEE_ALG_RSASSA_PKCS1_PSS_MGF1_SHA256
- TEE_ALG_RSASSA_PKCS1_PSS_MGF1_SHA384
- TEE_ALG_RSASSA_PKCS1_PSS_MGF1_SHA512

Also add support to select algorithm at runtime. The user can now run the `optee_example_sign_verify <key_size> <algo name>` command, and the specified algorithm will be used during sign/verify.

The user can now invoke:
optee_example_sign_verify <key_size> <algo name>

Supported values for <key_size> are:
- 2048 bits
- 3072 bits
- 4096 bits

Supported values for <algo name> are:
- TA_ALG_PKCS1_V1_5_SHA1
- TA_ALG_PKCS1_V1_5_SHA224
- TA_ALG_PKCS1_V1_5_SHA256
- TA_ALG_PKCS1_V1_5_SHA384
- TA_ALG_PKCS1_V1_5_SHA512
- TA_ALG_PKCS1_PSS_MGF1_SHA1
- TA_ALG_PKCS1_PSS_MGF1_SHA224
- TA_ALG_PKCS1_PSS_MGF1_SHA256
- TA_ALG_PKCS1_PSS_MGF1_SHA384
- TA_ALG_PKCS1_PSS_MGF1_SHA512

If no algorithm is specified, TA_ALG_PKCS1_V1_5_SHA256 is selected by default.

Based on the input, the corresponding algorithm and key size is selected and used for sign/verify operations. This enhancement improves flexibility by allowing users to test different RSA modes using a single binary.