### PR TITLE
base_sha: Add support for basic SHA algorithms

### DIFF
--- a/base_sha/Android.mk
+++ b/base_sha/Android.mk
@@ -1,0 +1,17 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+LOCAL_CFLAGS += -DANDROID_BUILD
+LOCAL_CFLAGS += -Wall
+
+LOCAL_SRC_FILES += host/main.c
+
+LOCAL_C_INCLUDES := $(LOCAL_PATH)/ta/include
+
+LOCAL_SHARED_LIBRARIES := libteec
+LOCAL_MODULE := optee_example_base_sha
+LOCAL_VENDOR_MODULE := true
+LOCAL_MODULE_TAGS := optional
+include $(BUILD_EXECUTABLE)
+
+include $(LOCAL_PATH)/ta/Android.mk

--- a/base_sha/CMakeLists.txt
+++ b/base_sha/CMakeLists.txt
@@ -1,0 +1,13 @@
+project (optee_example_base_sha C)
+
+set (SRC host/main.c)
+
+add_executable (${PROJECT_NAME} ${SRC})
+
+target_include_directories(${PROJECT_NAME}
+			   PRIVATE ta/include
+			   PRIVATE include)
+
+target_link_libraries (${PROJECT_NAME} PRIVATE teec)
+
+install (TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/base_sha/Makefile
+++ b/base_sha/Makefile
@@ -1,0 +1,15 @@
+export V ?= 0
+
+# If _HOST or _TA specific compilers are not specified, then use CROSS_COMPILE
+HOST_CROSS_COMPILE ?= $(CROSS_COMPILE)
+TA_CROSS_COMPILE ?= $(CROSS_COMPILE)
+
+.PHONY: all
+all:
+	$(MAKE) -C host CROSS_COMPILE="$(HOST_CROSS_COMPILE)" --no-builtin-variables
+	$(MAKE) -C ta CROSS_COMPILE="$(TA_CROSS_COMPILE)" LDFLAGS=""
+
+.PHONY: clean
+clean:
+	$(MAKE) -C host clean
+	$(MAKE) -C ta clean

--- a/base_sha/host/Makefile
+++ b/base_sha/host/Makefile
@@ -1,0 +1,28 @@
+CC      ?= $(CROSS_COMPILE)gcc
+LD      ?= $(CROSS_COMPILE)ld
+AR      ?= $(CROSS_COMPILE)ar
+NM      ?= $(CROSS_COMPILE)nm
+OBJCOPY ?= $(CROSS_COMPILE)objcopy
+OBJDUMP ?= $(CROSS_COMPILE)objdump
+READELF ?= $(CROSS_COMPILE)readelf
+
+OBJS = main.o
+
+CFLAGS += -Wall -I../ta/include -I./include
+CFLAGS += -I$(TEEC_EXPORT)/include
+LDADD += -lteec -L$(TEEC_EXPORT)/lib
+
+BINARY = optee_example_base_sha
+
+.PHONY: all
+all: $(BINARY)
+
+$(BINARY): $(OBJS)
+	$(CC) $(LDFLAGS) -o $@ $< $(LDADD)
+
+.PHONY: clean
+clean:
+	rm -f $(OBJS) $(BINARY)
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@

--- a/base_sha/host/main.c
+++ b/base_sha/host/main.c
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+ */
+
+#include <err.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <tee_client_api.h>
+
+#include <base_sha_ta.h>
+
+struct base_sha_ctx {
+	TEEC_Context ctx;
+	TEEC_Session sess;
+	uint32_t selected_algo;
+};
+
+static void usage(int argc, char *argv[])
+{
+	const char *pname = "base_sha";
+
+	if (argc)
+		pname = argv[0];
+
+	fprintf(stderr, "%s: %s <string to encrypt> <algo name>\n",
+		__func__, pname);
+	printf("SUPPORTED ALGORITHMS:\n");
+	printf("SHA1 - TA_ALG_SHA1\n");
+	printf("SHA224 - TA_ALG_SHA224\n");
+	printf("SHA256 - TA_ALG_SHA256\n");
+	printf("SHA384 - TA_ALG_SHA384\n");
+	printf("SHA512 - TA_ALG_SHA512\n");
+	printf("SHA3_224 - TA_ALG_SHA3_224\n");
+	printf("SHA3_256 - TA_ALG_SHA3_256\n");
+	printf("SHA3_384 - TA_ALG_SHA3_384\n");
+	printf("SHA3_512 - TA_ALG_SHA3_512\n");
+	printf("SHAKE128 - TA_ALG_SHAKE128\n");
+	printf("SHAKE256 - TA_ALG_SHAKE256\n");
+	exit(1);
+}
+
+static void get_args(int argc, char *argv[], void **msg, size_t *msg_len,
+		     uint32_t *algo_num)
+{
+	char *algo;
+
+	if ((argc < 2) || (argc > 3)) {
+		warnx("Unexpected number of arguments %d (expected 2)",
+		      argc - 1);
+		usage(argc, argv);
+	}
+
+	*msg = argv[1];
+	*msg_len = strlen(argv[1]);
+
+	if (argc > 2) {
+		algo = argv[2];
+		printf("%s algo selected\n", algo);
+		if (strcmp(algo, "TA_ALG_SHA1") == 0) {
+			*algo_num = TA_ALG_SHA1;
+		} else if (strcmp(algo, "TA_ALG_SHA224") == 0) {
+			*algo_num = TA_ALG_SHA224;
+		} else if (strcmp(algo, "TA_ALG_SHA256") == 0) {
+			*algo_num = TA_ALG_SHA256;
+		} else if (strcmp(algo, "TA_ALG_SHA384") == 0) {
+			*algo_num = TA_ALG_SHA384;
+		} else if (strcmp(algo, "TA_ALG_SHA512") == 0) {
+			*algo_num = TA_ALG_SHA512;
+		} else if (strcmp(algo, "TA_ALG_SHA3_224") == 0) {
+			*algo_num = TA_ALG_SHA3_224;
+		} else if (strcmp(algo, "TA_ALG_SHA3_256") == 0) {
+			*algo_num = TA_ALG_SHA3_256;
+		} else if (strcmp(algo, "TA_ALG_SHA3_384") == 0) {
+			*algo_num = TA_ALG_SHA3_384;
+		} else if (strcmp(algo, "TA_ALG_SHA3_512") == 0) {
+			*algo_num = TA_ALG_SHA3_512;
+		} else if (strcmp(algo, "TA_ALG_SHAKE128") == 0) {
+			*algo_num = TA_ALG_SHAKE128;
+		} else if (strcmp(algo, "TA_ALG_SHAKE256") == 0) {
+			*algo_num = TA_ALG_SHAKE256;
+		} else {
+			printf("%s algo is invalid\n", algo);
+			usage(argc, argv);
+		}
+	} else {
+		printf("TA_ALG_SHA256 algo selected\n");
+		*algo_num = TA_ALG_SHA256;
+	}
+}
+
+void compute_digest(struct base_sha_ctx *ctx, void *message, size_t msg_len,
+		    void *digest, size_t *digest_len)
+{
+	TEEC_Operation op;
+	uint32_t origin;
+	TEEC_Result res;
+
+	memset(&op, 0, sizeof(op));
+	op.paramTypes = TEEC_PARAM_TYPES(TEEC_MEMREF_TEMP_INPUT,
+					 TEEC_MEMREF_TEMP_OUTPUT,
+					 TEEC_VALUE_INPUT,
+					 TEEC_NONE);
+	op.params[0].tmpref.buffer = message;
+	op.params[0].tmpref.size = msg_len;
+	op.params[1].tmpref.buffer = digest;
+	op.params[1].tmpref.size = *digest_len;
+	op.params[2].value.a = ctx->selected_algo;
+
+	res = TEEC_InvokeCommand(&ctx->sess, CMD_COMPUTE_DIGEST, &op,
+				 &origin);
+	if (res == TEEC_SUCCESS) {
+		*digest_len = op.params[1].tmpref.size;
+	} else {
+		errx(1, "TEEC_InvokeCommand(COMPUTE DIGEST) failed 0x%x origin 0x%x",
+		     res, origin);
+	}
+}
+
+void prepare_tee_session(struct base_sha_ctx *ctx)
+{
+	TEEC_UUID uuid = TA_BASE_SHA_UUID;
+	uint32_t origin;
+	TEEC_Result res;
+
+	res = TEEC_InitializeContext(NULL, &ctx->ctx);
+	if (res != TEEC_SUCCESS)
+		errx(1, "TEEC_InitializeContext failed with code 0x%x", res);
+
+	res = TEEC_OpenSession(&ctx->ctx, &ctx->sess, &uuid,
+			       TEEC_LOGIN_PUBLIC, NULL, NULL, &origin);
+
+	if (res != TEEC_SUCCESS)
+		errx(1, "TEEC_Opensession failed with code 0x%x origin 0x%x",
+		     res, origin);
+}
+
+void terminate_tee_session(struct base_sha_ctx *sess)
+{
+	TEEC_CloseSession(&sess->sess);
+	TEEC_FinalizeContext(&sess->ctx);
+}
+
+int main(int argc, char *argv[])
+{
+	struct base_sha_ctx ctx;
+	void *msg;
+	size_t msg_len;
+	uint8_t digest[64];
+	size_t digest_len = sizeof(digest);
+
+	printf("Getting arg\n");
+	get_args(argc, argv, &msg, &msg_len, &ctx.selected_algo);
+
+	printf("Prepare session with the TA\n");
+	prepare_tee_session(&ctx);
+
+	printf("Compute digest\n");
+	compute_digest(&ctx, msg, msg_len, (void *)digest, &digest_len);
+
+	printf("digest:");
+	for (size_t i = 0; i < digest_len; i++)
+		printf("%02x ", digest[i]);
+	printf("\n");
+
+	terminate_tee_session(&ctx);
+	return 0;
+}

--- a/base_sha/ta/Android.mk
+++ b/base_sha/ta/Android.mk
@@ -1,0 +1,3 @@
+LOCAL_PATH := $(call my-dir)
+local_module := abb97be3-f56b-46d5-b7fd-70f28cfed992.ta
+include $(BUILD_OPTEE_MK)

--- a/base_sha/ta/Makefile
+++ b/base_sha/ta/Makefile
@@ -1,0 +1,13 @@
+CFG_TEE_TA_LOG_LEVEL ?= 4
+CFG_TA_OPTEE_CORE_API_COMPAT_1_1=y
+
+# The UUID for the Trusted Application
+BINARY=abb97be3-f56b-46d5-b7fd-70f28cfed992
+
+-include $(TA_DEV_KIT_DIR)/mk/ta_dev_kit.mk
+
+ifeq ($(wildcard $(TA_DEV_KIT_DIR)/mk/ta_dev_kit.mk), )
+clean:
+	@echo 'Note: $$(TA_DEV_KIT_DIR)/mk/ta_dev_kit.mk not found, cannot clean TA'
+	@echo 'Note: TA_DEV_KIT_DIR=$(TA_DEV_KIT_DIR)'
+endif

--- a/base_sha/ta/base_sha_ta.c
+++ b/base_sha/ta/base_sha_ta.c
@@ -1,0 +1,171 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+ */
+
+#include <tee_internal_api.h>
+#include <tee_internal_api_extensions.h>
+#include <string.h>
+#include <stdio.h>
+
+#include <base_sha_ta.h>
+
+struct base_sha {
+	uint32_t algo_id;
+};
+
+TEE_Result TA_CreateEntryPoint(void)
+{
+	DMSG("TA created");
+	return TEE_SUCCESS;
+}
+
+void TA_DestroyEntryPoint(void)
+{
+	/* TA destroyed */
+}
+
+TEE_Result TA_OpenSessionEntryPoint(uint32_t param_types,
+				    TEE_Param params[4],
+				    void **sess_ctx)
+{
+	struct base_sha *sess;
+
+	sess = TEE_Malloc(sizeof(*sess), 0);
+	if (!sess)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	(void)param_types;
+	(void)params;
+
+	*sess_ctx = (void *)sess;
+	DMSG("Session %p: newly allocated", *sess_ctx);
+	return TEE_SUCCESS;
+}
+
+void TA_CloseSessionEntryPoint(void *sess_ctx)
+{
+	struct base_sha *sess;
+
+	sess = (struct base_sha *)sess_ctx;
+	/* release session */
+	TEE_Free(sess);
+}
+
+static TEE_Result ta2tee_algo_id(uint32_t param, uint32_t *algo_id)
+{
+	switch (param) {
+	case TA_ALG_SHA1:
+		*algo_id = TEE_ALG_SHA1;
+		return TEE_SUCCESS;
+	case TA_ALG_SHA224:
+		*algo_id = TEE_ALG_SHA224;
+		return TEE_SUCCESS;
+	case TA_ALG_SHA256:
+		*algo_id = TEE_ALG_SHA256;
+		return TEE_SUCCESS;
+	case TA_ALG_SHA384:
+		*algo_id = TEE_ALG_SHA384;
+		return TEE_SUCCESS;
+	case TA_ALG_SHA512:
+		*algo_id = TEE_ALG_SHA512;
+		return TEE_SUCCESS;
+	case TA_ALG_SHA3_224:
+		*algo_id = TEE_ALG_SHA3_224;
+		return TEE_SUCCESS;
+	case TA_ALG_SHA3_256:
+		*algo_id = TEE_ALG_SHA3_256;
+		return TEE_SUCCESS;
+	case TA_ALG_SHA3_384:
+		*algo_id = TEE_ALG_SHA3_384;
+		return TEE_SUCCESS;
+	case TA_ALG_SHA3_512:
+		*algo_id = TEE_ALG_SHA3_512;
+		return TEE_SUCCESS;
+	case TA_ALG_SHAKE128:
+		*algo_id = TEE_ALG_SHAKE128;
+		return TEE_SUCCESS;
+	case TA_ALG_SHAKE256:
+		*algo_id = TEE_ALG_SHAKE256;
+		return TEE_SUCCESS;
+	default:
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+}
+
+static TEE_Result compute_digest(void *session, uint32_t param_types,
+				 TEE_Param params[4])
+{
+	const uint32_t exp_param_types =
+		TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
+				TEE_PARAM_TYPE_MEMREF_OUTPUT,
+				TEE_PARAM_TYPE_VALUE_INPUT,
+				TEE_PARAM_TYPE_NONE);
+	if (param_types != exp_param_types)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	struct base_sha *sess;
+	TEE_OperationHandle op;
+	TEE_Result res = TEE_ERROR_OUT_OF_MEMORY;
+	void *msg = params[0].memref.buffer;
+	size_t msg_len = params[0].memref.size;
+	uint32_t digest_len = params[1].memref.size;
+	uint32_t param = params[2].value.a;
+	void *b2 = NULL;
+
+	DMSG("Session %p: get compute digest", session);
+	sess = (struct base_sha *)session;
+
+	if (params[1].memref.buffer && params[1].memref.size) {
+		b2 = TEE_Malloc(params[1].memref.size, 0);
+		if (!b2)
+			goto out;
+	}
+
+	res = ta2tee_algo_id(param, &sess->algo_id);
+	if (res != TEE_SUCCESS)
+		goto out;
+
+	res = TEE_AllocateOperation(&op, sess->algo_id, TEE_MODE_DIGEST, 0);
+	if (res != TEE_SUCCESS)
+		goto out;
+
+	TEE_DigestUpdate(op, msg, msg_len);
+
+	res = TEE_DigestDoFinal(op, NULL, 0, b2, &digest_len);
+	if (res == TEE_SUCCESS) {
+		if (b2) {
+			TEE_MemMove(params[1].memref.buffer, b2,
+				    digest_len);
+		} else {
+			EMSG("Digest not genrated");
+			res = TEE_ERROR_SHORT_BUFFER;
+			goto out;
+		}
+	} else {
+		EMSG("TEE_DigestDoFinal failed\n");
+		goto out;
+	}
+
+	params[1].memref.size = digest_len;
+
+	DMSG("Created digest");
+	TEE_FreeOperation(op);
+
+out:
+	TEE_Free(b2);
+	return res;
+}
+
+TEE_Result TA_InvokeCommandEntryPoint(void *session, uint32_t cmd,
+				      uint32_t param_types,
+				      TEE_Param params[4])
+{
+	switch (cmd) {
+	case CMD_COMPUTE_DIGEST:
+		return compute_digest(session, param_types, params);
+	default:
+		EMSG("cmd id not supported");
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+}

--- a/base_sha/ta/include/base_sha_ta.h
+++ b/base_sha/ta/include/base_sha_ta.h
@@ -1,0 +1,29 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+ */
+
+#ifndef __BASE_SHA_TA_H__
+#define __BASE_SHA_TA_H__
+
+/* UUID of the AES example trusted application */
+
+#define TA_BASE_SHA_UUID \
+	{ 0xabb97be3, 0xf56b, 0x46d5, \
+		{ 0xb7, 0xfd, 0x70, 0xf2, 0x8c, 0xfe, 0xd9, 0x92 } }
+
+#define CMD_COMPUTE_DIGEST	0
+
+#define TA_ALG_SHA1		0
+#define TA_ALG_SHA224		1
+#define TA_ALG_SHA256		2
+#define TA_ALG_SHA384		3
+#define TA_ALG_SHA512		4
+#define TA_ALG_SHA3_224		5
+#define TA_ALG_SHA3_256		6
+#define TA_ALG_SHA3_384		7
+#define TA_ALG_SHA3_512		8
+#define TA_ALG_SHAKE128		9
+#define TA_ALG_SHAKE256		10
+
+#endif

--- a/base_sha/ta/sub.mk
+++ b/base_sha/ta/sub.mk
@@ -1,0 +1,2 @@
+global-incdirs-y += include
+srcs-y += base_sha_ta.c

--- a/base_sha/ta/user_ta_header_defines.h
+++ b/base_sha/ta/user_ta_header_defines.h
@@ -1,0 +1,27 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+ */
+
+#ifndef USER_TA_HEADER_DEFINES_H
+#define USER_TA_HEADER_DEFINES_H
+
+#include <base_sha_ta.h>
+
+#define TA_UUID				TA_BASE_SHA_UUID
+
+#define TA_FLAGS			TA_FLAG_EXEC_DDR
+
+/* Provisioned stack size */
+#define TA_STACK_SIZE			(2 * 1024)
+
+/* Provisioned heap size for TEE_Malloc() and friends */
+#define TA_DATA_SIZE			(32 * 1024)
+
+/* The gpd.ta.version property */
+#define TA_VERSION	"1.0"
+
+/* The gpd.ta.description property */
+#define TA_DESCRIPTION	"Example of TA using an basic SHA sequence"
+
+#endif /*USER_TA_HEADER_DEFINES_H*/


### PR DESCRIPTION
Add support for new basic SHA algorithms:
- TEE_ALG_SHA1
- TEE_ALG_SHA224
- TEE_ALG_SHA256
- TEE_ALG_SHA384
- TEE_ALG_SHA512
- TEE_ALG_SHA3_224
- TEE_ALG_SHA3_256
- TEE_ALG_SHA3_384
- TEE_ALG_SHA3_512
- TEE_ALG_SHAKE128
- TEE_ALG_SHAKE256

Also add support to select algorithm at runtime. The user can now run the `optee_example_base_sha <string to encrypt> <algo name>` command, and the specified algorithm will be used for computing digest.

The user can now invoke:
optee_example_base_sha <string to encrypt> <algo name>

Supported values for <algo name> are:
- TA_ALG_SHA1
- TA_ALG_SHA224
- TA_ALG_SHA256
- TA_ALG_SHA384
- TA_ALG_SHA512
- TA_ALG_SHA3_224
- TA_ALG_SHA3_256
- TA_ALG_SHA3_384
- TA_ALG_SHA3_512
- TA_ALG_SHAKE128
- TA_ALG_SHAKE256

If no algorithm is specified, TA_ALG_SHA256 is selected by default.

Based on the input, the corresponding algorithm is selected and used for computing digest operations. This enhancement improves flexibility by allowing users to test different basic SHA modes using a single binary.