### PR TITLE
acipher: add dynamic algorithm selection and decryption support

### DIFF
--- a/acipher/ta/include/acipher_ta.h
+++ b/acipher/ta/include/acipher_ta.h
@@ -17,9 +17,19 @@
 #define TA_ACIPHER_CMD_GEN_KEY		0
 
 /*
- * in	params[1].memref  input
- * out	params[2].memref  output
+ * in	params[0].memref  Input data to cipher
+ * out	params[1].memref  Ciphered output data
+ * in   params[2].value.a  Mode: 0 for decryption, any other value for
+ * encryption
+ * in   params[3].value.a  Algorithm (TA_ALG_*)
  */
-#define TA_ACIPHER_CMD_ENCRYPT		1
+#define TA_ACIPHER_CMD_ENCRYPT_DECRYPT	1
+
+#define TA_ALG_PKCS1_V1_5		0x60000130
+#define TA_ALG_OAEP_MGF1_SHA1		0x60210230
+#define TA_ALG_OAEP_MGF1_SHA224		0x60310230
+#define TA_ALG_OAEP_MGF1_SHA256		0x60410230
+#define TA_ALG_OAEP_MGF1_SHA384		0x60510230
+#define TA_ALG_OAEP_MGF1_SHA512		0x60610230
 
 #endif /* __ACIPHER_TA_H */


### PR DESCRIPTION
- Extend acipher example to support for RSA algorithms:
  - TEE_ALG_RSAES_PKCS1_V1_5
  - TEE_ALG_RSAES_PKCS1_OAEP_MGF1_SHA1/224/256/384/512
- Users can select algorithm and key size at runtime via: `optee_example_acipher <key_size> <string> <algo>`
- Supported key sizes: 2048, 3072, 4096 bits
- Defaults to TA_ALG_PKCS1_V1_5 if no algorithm is specified
- Enhances the acipher example for flexible testing of multiple RSA modes