### PR TITLE
ecdsa: add new example with runtime algo selection

### DIFF
--- a/ecdsa/Android.mk
+++ b/ecdsa/Android.mk
@@ -1,0 +1,17 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+LOCAL_CFLAGS += -DANDROID_BUILD
+LOCAL_CFLAGS += -Wall
+
+LOCAL_SRC_FILES += host/main.c
+
+LOCAL_C_INCLUDES := $(LOCAL_PATH)/ta/include
+
+LOCAL_SHARED_LIBRARIES := libteec
+LOCAL_MODULE := optee_example_ecdsa
+LOCAL_VENDOR_MODULE := true
+LOCAL_MODULE_TAGS := optional
+include $(BUILD_EXECUTABLE)
+
+include $(LOCAL_PATH)/ta/Android.mk

--- a/ecdsa/CMakeLists.txt
+++ b/ecdsa/CMakeLists.txt
@@ -1,0 +1,13 @@
+project (optee_example_ecdsa C)
+
+set (SRC host/main.c)
+
+add_executable (${PROJECT_NAME} ${SRC})
+
+target_include_directories(${PROJECT_NAME}
+			   PRIVATE ta/include
+			   PRIVATE include)
+
+target_link_libraries (${PROJECT_NAME} PRIVATE teec)
+
+install (TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/ecdsa/Makefile
+++ b/ecdsa/Makefile
@@ -1,0 +1,15 @@
+export V ?= 0
+
+# If _HOST or _TA specific compilers are not specified, then use CROSS_COMPILE
+HOST_CROSS_COMPILE ?= $(CROSS_COMPILE)
+TA_CROSS_COMPILE ?= $(CROSS_COMPILE)
+
+.PHONY: all
+all:
+	$(MAKE) -C host CROSS_COMPILE="$(HOST_CROSS_COMPILE)" --no-builtin-variables
+	$(MAKE) -C ta CROSS_COMPILE="$(TA_CROSS_COMPILE)" LDFLAGS=""
+
+.PHONY: clean
+clean:
+	$(MAKE) -C host clean
+	$(MAKE) -C ta clean

--- a/ecdsa/host/Makefile
+++ b/ecdsa/host/Makefile
@@ -1,0 +1,28 @@
+CC      ?= $(CROSS_COMPILE)gcc
+LD      ?= $(CROSS_COMPILE)ld
+AR      ?= $(CROSS_COMPILE)ar
+NM      ?= $(CROSS_COMPILE)nm
+OBJCOPY ?= $(CROSS_COMPILE)objcopy
+OBJDUMP ?= $(CROSS_COMPILE)objdump
+READELF ?= $(CROSS_COMPILE)readelf
+
+OBJS = main.o
+
+CFLAGS += -Wall -I../ta/include -I./include
+CFLAGS += -I$(TEEC_EXPORT)/include
+LDADD += -lteec -L$(TEEC_EXPORT)/lib
+
+BINARY = optee_example_ecdsa
+
+.PHONY: all
+all: $(BINARY)
+
+$(BINARY): $(OBJS)
+	$(CC) $(LDFLAGS) -o $@ $< $(LDADD)
+
+.PHONY: clean
+clean:
+	rm -f $(OBJS) $(BINARY)
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@

--- a/ecdsa/host/main.c
+++ b/ecdsa/host/main.c
@@ -1,0 +1,175 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+ */
+
+#include <err.h>
+#include <stdio.h>
+#include <string.h>
+#include <tee_client_api.h>
+
+#include <ecdsa_ta.h>
+
+struct ecdsa_ctx {
+	TEEC_Context ctx;
+	TEEC_Session sess;
+	uint32_t selected_algo;
+};
+
+void prepare_tee_session(struct ecdsa_ctx *ctx)
+{
+	TEEC_UUID uuid = TA_ECDSA_UUID;
+	uint32_t origin;
+	TEEC_Result res;
+
+	res = TEEC_InitializeContext(NULL, &ctx->ctx);
+	if (res != TEEC_SUCCESS)
+		errx(1, "TEEC_InitializeContext failed with code 0x%x", res);
+
+	res = TEEC_OpenSession(&ctx->ctx, &ctx->sess, &uuid,
+			       TEEC_LOGIN_PUBLIC, NULL, NULL, &origin);
+	if (res != TEEC_SUCCESS)
+		errx(1, "TEEC_Opensession failed with code 0x%x origin 0x%x",
+		     res, origin);
+}
+
+void terminate_tee_session(struct ecdsa_ctx *sess)
+{
+	TEEC_CloseSession(&sess->sess);
+	TEEC_FinalizeContext(&sess->ctx);
+}
+
+void compute_digest(struct ecdsa_ctx *ctx, void *message, size_t msg_len,
+		    void *digest, size_t *digest_len)
+{
+	TEEC_Operation op;
+	uint32_t origin;
+	TEEC_Result res;
+
+	memset(&op, 0, sizeof(op));
+	op.paramTypes = TEEC_PARAM_TYPES(TEEC_MEMREF_TEMP_INPUT,
+					 TEEC_MEMREF_TEMP_OUTPUT,
+					 TEEC_VALUE_INPUT,
+					 TEEC_NONE);
+	op.params[0].tmpref.buffer = message;
+	op.params[0].tmpref.size = msg_len;
+	op.params[1].tmpref.buffer = digest;
+	op.params[1].tmpref.size = *digest_len;
+	op.params[2].value.a = ctx->selected_algo;
+
+	res = TEEC_InvokeCommand(&ctx->sess, CMD_COMPUTE_DIGEST, &op,
+				 &origin);
+	if (res == TEEC_SUCCESS) {
+		*digest_len = op.params[1].tmpref.size;
+	} else {
+		errx(1, "TEEC_InvokeCommand(COMPUTE DIGEST) failed 0x%x origin 0x%x",
+		     res, origin);
+	}
+
+}
+
+void genrate_key(struct ecdsa_ctx *ctx)
+{
+	TEEC_Operation op;
+	uint32_t origin;
+	TEEC_Result res;
+
+	memset(&op, 0, sizeof(op));
+	op.paramTypes = TEEC_PARAM_TYPES(TEEC_NONE, TEEC_NONE,
+					 TEEC_NONE, TEEC_NONE);
+
+	res = TEEC_InvokeCommand(&ctx->sess, GEN_KEY, &op, &origin);
+	if (res != TEEC_SUCCESS)
+		errx(1, "TEEC_InvokeCommand(Genrate Key) failed 0x%x origin 0x%x",
+		     res, origin);
+}
+
+TEEC_Result sign_verify_digest(struct ecdsa_ctx *ctx, void *sig, size_t *sig_len,
+			void *digest, size_t digest_len)
+{
+	TEEC_Operation op;
+	uint32_t origin;
+	TEEC_Result res;
+
+	memset(&op, 0, sizeof(op));
+	op.paramTypes = TEEC_PARAM_TYPES(TEEC_MEMREF_TEMP_INPUT,
+					 TEEC_MEMREF_TEMP_OUTPUT,
+					 TEEC_NONE, TEEC_NONE);
+	op.params[0].tmpref.buffer = digest;
+	op.params[0].tmpref.size = digest_len;
+	op.params[1].tmpref.buffer = sig;
+	op.params[1].tmpref.size = *sig_len;
+
+	res = TEEC_InvokeCommand(&ctx->sess, SIGN_VERIFY_DIGEST, &op,
+				       &origin);
+	if (res == TEEC_SUCCESS) {
+		*sig_len = op.params[1].tmpref.size;
+	} else {
+		printf("TEEC_InvokeCommand(Sign Verify) failed 0x%x origin 0x%x",
+		     res, origin);
+	}
+	return res;
+}
+
+int main(int argc, char *argv[])
+{
+	struct ecdsa_ctx ctx;
+	TEEC_Result res;
+	char message[] = "hello world";
+	size_t msg_len = strlen(message);
+	uint8_t sig[512];
+	size_t sig_len = sizeof(sig);
+	uint8_t digest[64];
+	size_t digest_len = sizeof(digest);
+	char *algo;
+
+	if (argc > 1) {
+		algo = argv[1];
+		printf("%s algo selected\n", algo);
+		if (strcmp(algo, "TA_ALG_ECDSA_SHA1") == 0) {
+			ctx.selected_algo = TA_ALG_ECDSA_SHA1;
+		} else if (strcmp(algo, "TA_ALG_ECDSA_SHA224") == 0) {
+			ctx.selected_algo = TA_ALG_ECDSA_SHA224;
+		} else if (strcmp(algo, "TA_ALG_ECDSA_SHA256") == 0) {
+			ctx.selected_algo = TA_ALG_ECDSA_SHA256;
+		} else if (strcmp(algo, "TA_ALG_ECDSA_SHA384") == 0) {
+			ctx.selected_algo = TA_ALG_ECDSA_SHA384;
+		} else if (strcmp(algo, "TA_ALG_ECDSA_SHA512") == 0) {
+			ctx.selected_algo = TA_ALG_ECDSA_SHA512;
+		} else {
+			printf("%s algo is invalid\n", algo);
+			return -1;
+		}
+	} else {
+		printf("TA_ALG_ECDSA_SHA256 algo selected\n");
+		ctx.selected_algo = TA_ALG_ECDSA_SHA256;
+	}
+
+	printf("Prepare session with the TA\n");
+	prepare_tee_session(&ctx);
+
+	printf("Compute digest\n");
+	compute_digest(&ctx, (void *)message, msg_len, (void *)digest,
+		       &digest_len);
+
+	printf("genrate the key\n");
+	genrate_key(&ctx);
+
+	printf("Sign and Verify the digest\n");
+	res = sign_verify_digest(&ctx, sig, &sig_len,
+				 (void *)digest, digest_len);
+	if (res != TEEC_SUCCESS) {
+		printf("sign failed to verify\n");
+		errx(1, "TEEC_InvokeCommand failed: 0x%x", res);
+	} else {
+		printf("verify signature successfully.\n");
+	}
+
+	printf("signature: ");
+	for (size_t i = 0; i < sig_len; i++)
+		printf("%02x ", sig[i]);
+	printf("\n");
+
+	terminate_tee_session(&ctx);
+	return 0;
+}

--- a/ecdsa/ta/Android.mk
+++ b/ecdsa/ta/Android.mk
@@ -1,0 +1,3 @@
+LOCAL_PATH := $(call my-dir)
+local_module := 1945e8e7-0278-4bfb-bb99-af1080b2a934.ta
+include $(BUILD_OPTEE_MK)

--- a/ecdsa/ta/Makefile
+++ b/ecdsa/ta/Makefile
@@ -1,0 +1,13 @@
+CFG_TEE_TA_LOG_LEVEL ?= 4
+CFG_TA_OPTEE_CORE_API_COMPAT_1_1=y
+
+# The UUID for the Trusted Application
+BINARY=1945e8e7-0278-4bfb-bb99-af1080b2a934
+
+-include $(TA_DEV_KIT_DIR)/mk/ta_dev_kit.mk
+
+ifeq ($(wildcard $(TA_DEV_KIT_DIR)/mk/ta_dev_kit.mk), )
+clean:
+	@echo 'Note: $$(TA_DEV_KIT_DIR)/mk/ta_dev_kit.mk not found, cannot clean TA'
+	@echo 'Note: TA_DEV_KIT_DIR=$(TA_DEV_KIT_DIR)'
+endif

--- a/ecdsa/ta/ecdsa_ta.c
+++ b/ecdsa/ta/ecdsa_ta.c
@@ -1,0 +1,342 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+ */
+
+#include <tee_internal_api.h>
+#include <tee_internal_api_extensions.h>
+#include <string.h>
+#include <stdio.h>
+
+#include <ecdsa_ta.h>
+
+struct ecdsa {
+	TEE_ObjectHandle keypair;
+	TEE_ObjectHandle public_key;
+	uint32_t algo_id;
+	uint32_t hash_algo;
+	uint32_t key_sz;
+};
+
+TEE_Result TA_CreateEntryPoint(void)
+{
+	DMSG("TA created");
+	return TEE_SUCCESS;
+}
+
+void TA_DestroyEntryPoint(void)
+{
+	/* TA destroyed */
+}
+
+TEE_Result TA_OpenSessionEntryPoint(uint32_t param_types,
+				    TEE_Param params[4],
+				    void **sess_ctx)
+{
+	struct ecdsa *sess;
+
+	sess = TEE_Malloc(sizeof(*sess), 0);
+	if (!sess)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	sess->keypair = TEE_HANDLE_NULL;
+	sess->public_key = TEE_HANDLE_NULL;
+
+	(void)param_types;
+	(void)params;
+
+	*sess_ctx = (void *)sess;
+	DMSG("Session %p: newly allocated", *sess_ctx);
+	return TEE_SUCCESS;
+
+}
+
+void TA_CloseSessionEntryPoint(void *sess_ctx)
+{
+	struct ecdsa *sess;
+
+	sess = (struct ecdsa *)sess_ctx;
+
+	/* release session */
+	if (sess->keypair != TEE_HANDLE_NULL)
+		TEE_FreeTransientObject(sess->keypair);
+	if (sess->public_key != TEE_HANDLE_NULL)
+		TEE_FreeTransientObject(sess->public_key);
+
+	TEE_Free(sess);
+}
+
+static TEE_Result get_hash_algo(uint32_t algo, uint32_t *hash_algo)
+{
+	switch (algo) {
+	case TEE_ALG_ECDSA_SHA1:
+		*hash_algo = TEE_ALG_SHA1;
+		return TEE_SUCCESS;
+	case TEE_ALG_ECDSA_SHA224:
+		*hash_algo = TEE_ALG_SHA224;
+		return TEE_SUCCESS;
+	case TEE_ALG_ECDSA_SHA256:
+		*hash_algo = TEE_ALG_SHA256;
+		return TEE_SUCCESS;
+	case TEE_ALG_ECDSA_SHA384:
+		*hash_algo = TEE_ALG_SHA384;
+		return TEE_SUCCESS;
+	case TEE_ALG_ECDSA_SHA512:
+		*hash_algo = TEE_ALG_SHA512;
+		return TEE_SUCCESS;
+	default:
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+}
+
+static TEE_Result ta2tee_algo_id(uint32_t param, uint32_t *algo_id)
+{
+	switch (param) {
+	case TA_ALG_ECDSA_SHA1:
+		*algo_id = TEE_ALG_ECDSA_SHA1;
+		return TEE_SUCCESS;
+	case TA_ALG_ECDSA_SHA224:
+		*algo_id = TEE_ALG_ECDSA_SHA224;
+		return TEE_SUCCESS;
+	case TA_ALG_ECDSA_SHA256:
+		*algo_id = TEE_ALG_ECDSA_SHA256;
+		return TEE_SUCCESS;
+	case TA_ALG_ECDSA_SHA384:
+		*algo_id = TEE_ALG_ECDSA_SHA384;
+		return TEE_SUCCESS;
+	case TA_ALG_ECDSA_SHA512:
+		*algo_id = TEE_ALG_ECDSA_SHA512;
+		return TEE_SUCCESS;
+	default:
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+}
+
+static TEE_Result compute_digest(void *session, uint32_t param_types,
+				 TEE_Param params[4])
+{
+	const uint32_t exp_param_types =
+		TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
+				TEE_PARAM_TYPE_MEMREF_OUTPUT,
+				TEE_PARAM_TYPE_VALUE_INPUT,
+				TEE_PARAM_TYPE_NONE);
+	if (param_types != exp_param_types)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	struct ecdsa *sess;
+	TEE_OperationHandle op;
+	TEE_Result res = TEE_ERROR_OUT_OF_MEMORY;
+	void *msg = params[0].memref.buffer;
+	size_t msg_len = params[0].memref.size;
+	uint32_t digest_len = params[1].memref.size;
+	uint32_t param = params[2].value.a;
+	void *b2 = NULL;
+
+	DMSG("Session %p: get compute digest", session);
+	sess = (struct ecdsa *)session;
+
+	if (params[1].memref.buffer && params[1].memref.size) {
+		b2 = TEE_Malloc(params[1].memref.size, 0);
+		if (!b2)
+			goto out;
+	}
+
+	res = ta2tee_algo_id(param, &sess->algo_id);
+	if (res != TEE_SUCCESS)
+		return res;
+
+	res = get_hash_algo(sess->algo_id, &sess->hash_algo);
+	if (res != TEE_SUCCESS)
+		return res;
+
+	res = TEE_AllocateOperation(&op, sess->hash_algo, TEE_MODE_DIGEST, 0);
+	if (res != TEE_SUCCESS)
+		return res;
+
+	TEE_DigestUpdate(op, msg, msg_len);
+
+	res = TEE_DigestDoFinal(op, NULL, 0, b2, &digest_len);
+	if (res == TEE_SUCCESS) {
+		if (b2) {
+			TEE_MemMove(params[1].memref.buffer, b2,
+				    digest_len);
+		}
+		params[1].memref.size = digest_len;
+	} else {
+		DMSG("TEE_DigestDoFinal failed\n");
+	}
+
+	DMSG("Created digest");
+	TEE_FreeOperation(op);
+out:
+	TEE_Free(b2);
+	return res;
+}
+
+static TEE_Result genrate_key(void *session, uint32_t param_types)
+{
+	uint32_t exp_param_types = TEE_PARAM_TYPES(TEE_PARAM_TYPE_NONE,
+						   TEE_PARAM_TYPE_NONE,
+						   TEE_PARAM_TYPE_NONE,
+						   TEE_PARAM_TYPE_NONE);
+	if (param_types != exp_param_types)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	TEE_Result res;
+	TEE_Attribute attr;
+	struct ecdsa *sess = (struct ecdsa *)session;
+	uint32_t key_size;
+	uint32_t curve;
+	uint32_t algo = sess->algo_id;
+
+	DMSG("Session %p: compute genrate key", session);
+
+	switch (algo) {
+	case TEE_ALG_ECDSA_SHA1:
+		curve = TEE_ECC_CURVE_NIST_P192;
+		key_size = 192;
+		break;
+	case TEE_ALG_ECDSA_SHA224:
+		curve = TEE_ECC_CURVE_NIST_P224;
+		key_size = 224;
+		break;
+	case TEE_ALG_ECDSA_SHA256:
+		curve = TEE_ECC_CURVE_NIST_P256;
+		key_size = 256;
+		break;
+	case TEE_ALG_ECDSA_SHA384:
+		curve = TEE_ECC_CURVE_NIST_P384;
+		key_size = 384;
+		break;
+	case TEE_ALG_ECDSA_SHA512:
+		curve = TEE_ECC_CURVE_NIST_P521;
+		key_size = 521;
+		break;
+	default:
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	if (sess->keypair != TEE_HANDLE_NULL)
+		TEE_FreeTransientObject(sess->keypair);
+	if (sess->public_key != TEE_HANDLE_NULL)
+		TEE_FreeTransientObject(sess->public_key);
+
+	res = TEE_AllocateTransientObject(TEE_TYPE_ECDSA_KEYPAIR, key_size,
+					  &sess->keypair);
+	if (res != TEE_SUCCESS)
+		return res;
+
+	TEE_InitValueAttribute(&attr, TEE_ATTR_ECC_CURVE, curve, 0);
+
+	res = TEE_GenerateKey(sess->keypair, key_size, &attr, 1);
+	if (res != TEE_SUCCESS)
+		return res;
+
+	res = TEE_AllocateTransientObject(TEE_TYPE_ECDSA_PUBLIC_KEY, key_size,
+					  &sess->public_key);
+	if (res != TEE_SUCCESS)
+		return res;
+
+	res = TEE_CopyObjectAttributes1(sess->public_key, sess->keypair);
+	if (res != TEE_SUCCESS) {
+		TEE_FreeTransientObject(sess->public_key);
+		TEE_FreeTransientObject(sess->keypair);
+		return res;
+	}
+
+	DMSG("Key generated");
+	sess->key_sz = key_size;
+	return TEE_SUCCESS;
+}
+
+static TEE_Result sign_verify_digest(void *session, uint32_t param_types,
+				     TEE_Param params[4])
+{
+
+	const uint32_t exp_param_types =
+		TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
+				TEE_PARAM_TYPE_MEMREF_OUTPUT,
+				TEE_PARAM_TYPE_NONE,
+				TEE_PARAM_TYPE_NONE);
+	if (param_types != exp_param_types)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	struct ecdsa *sess;
+	TEE_OperationHandle sign_op = TEE_HANDLE_NULL;
+	TEE_OperationHandle verify_op = TEE_HANDLE_NULL;
+	TEE_Result res;
+	void *digest;
+	uint32_t digest_len;
+	void *out;
+	size_t out_len;
+	uint8_t sig[512];
+	uint32_t sig_len = sizeof(sig);
+
+	DMSG("Session %p: Sign and Verify", session);
+
+	sess = (struct ecdsa *)session;
+	digest = params[0].memref.buffer;
+	digest_len = (uint32_t)params[0].memref.size;
+	out = params[1].memref.buffer;
+	out_len = params[1].memref.size;
+
+	DMSG("Sign SHA Digest\n");
+	res = TEE_AllocateOperation(&sign_op, sess->algo_id,
+				    TEE_MODE_SIGN, sess->key_sz);
+	if (res != TEE_SUCCESS)
+		goto exit;
+	res = TEE_SetOperationKey(sign_op, sess->keypair);
+	if (res != TEE_SUCCESS)
+		goto exit;
+	res = TEE_AsymmetricSignDigest(sign_op, NULL, 0, digest, digest_len,
+				       sig, &sig_len);
+	if (res != TEE_SUCCESS)
+		goto exit;
+
+	DMSG("Verify Signature on SHA digest");
+	res = TEE_AllocateOperation(&verify_op, sess->algo_id, TEE_MODE_VERIFY,
+				    sess->key_sz);
+	if (res != TEE_SUCCESS)
+		goto exit;
+	res = TEE_SetOperationKey(verify_op, sess->public_key);
+	if (res != TEE_SUCCESS)
+		goto exit;
+	res = TEE_AsymmetricVerifyDigest(verify_op, NULL, 0, digest,
+					 digest_len, sig, sig_len);
+	if (res != TEE_SUCCESS)
+		goto exit;
+
+	if (out_len < sig_len) {
+		EMSG("reqired seg size is %u", params[1].memref.size);
+		params[1].memref.size = sig_len;
+		res = TEE_ERROR_SHORT_BUFFER;
+		goto exit;
+	}
+
+	TEE_MemMove(out, sig, sig_len);
+	params[1].memref.size = sig_len;
+
+exit:
+	TEE_FreeOperation(sign_op);
+	TEE_FreeOperation(verify_op);
+
+	return res;
+
+}
+
+TEE_Result TA_InvokeCommandEntryPoint(void *session, uint32_t cmd,
+				      uint32_t param_types,
+				      TEE_Param params[4])
+{
+	switch (cmd) {
+	case CMD_COMPUTE_DIGEST:
+		return compute_digest(session, param_types, params);
+	case GEN_KEY:
+		return genrate_key(session, param_types);
+	case SIGN_VERIFY_DIGEST:
+		return sign_verify_digest(session, param_types, params);
+	default:
+		EMSG("cmd id not supported");
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+}

--- a/ecdsa/ta/include/ecdsa_ta.h
+++ b/ecdsa/ta/include/ecdsa_ta.h
@@ -1,0 +1,25 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+ */
+
+#ifndef __ECDSA_TA_H__
+#define __ECDSA_TA_H__
+
+/* UUID of the AES example trusted application */
+
+#define TA_ECDSA_UUID \
+	{ 0x1945e8e7, 0x0278, 0x4bfb, \
+		{ 0xbb, 0x99, 0xaf, 0x10, 0x80, 0xb2, 0xa9, 0x34 } }
+
+#define CMD_COMPUTE_DIGEST	0
+#define GEN_KEY			1
+#define SIGN_VERIFY_DIGEST	2
+
+#define TA_ALG_ECDSA_SHA1	0
+#define TA_ALG_ECDSA_SHA224	1
+#define TA_ALG_ECDSA_SHA256	2
+#define TA_ALG_ECDSA_SHA384	3
+#define TA_ALG_ECDSA_SHA512	4
+
+#endif

--- a/ecdsa/ta/sub.mk
+++ b/ecdsa/ta/sub.mk
@@ -1,0 +1,2 @@
+global-incdirs-y += include
+srcs-y += ecdsa_ta.c

--- a/ecdsa/ta/user_ta_header_defines.h
+++ b/ecdsa/ta/user_ta_header_defines.h
@@ -1,0 +1,27 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+ */
+
+#ifndef USER_TA_HEADER_DEFINES_H
+#define USER_TA_HEADER_DEFINES_H
+
+#include <ecdsa_ta.h>
+
+#define TA_UUID				TA_ECDSA_UUID
+
+#define TA_FLAGS			TA_FLAG_EXEC_DDR
+
+/* Provisioned stack size */
+#define TA_STACK_SIZE			(2 * 1024)
+
+/* Provisioned heap size for TEE_Malloc() and friends */
+#define TA_DATA_SIZE			(32 * 1024)
+
+/* The gpd.ta.version property */
+#define TA_VERSION	"1.0"
+
+/* The gpd.ta.description property */
+#define TA_DESCRIPTION	"Example of TA using an ECDSA Sign and Verify sequence"
+
+#endif /*USER_TA_HEADER_DEFINES_H*/


### PR DESCRIPTION
Add new example demonstrating ECDSA algorithms:
  - TEE_ALG_ECDSA_SHA1
  - TEE_ALG_ECDSA_SHA224
  - TEE_ALG_ECDSA_SHA256
  - TEE_ALG_ECDSA_SHA384
  - TEE_ALG_ECDSA_SHA512
- Allows users to select algorithm at runtime via: `optee_example_ecdsa <algo>`
- Defaults to TA_ALG_ECDSA_SHA256 if no algorithm is specified
- The selected algorithm is used for ECDSA operations