### PR TITLE
sha: new example for SHA HMAC and Digest algos

### DIFF
--- a/sha/Android.mk
+++ b/sha/Android.mk
@@ -1,0 +1,17 @@
+LOCAL_PATH := $(call my-dir)
+
+include $(CLEAR_VARS)
+LOCAL_CFLAGS += -DANDROID_BUILD
+LOCAL_CFLAGS += -Wall
+
+LOCAL_SRC_FILES += host/main.c
+
+LOCAL_C_INCLUDES := $(LOCAL_PATH)/ta/include
+
+LOCAL_SHARED_LIBRARIES := libteec
+LOCAL_MODULE := optee_example_sha
+LOCAL_VENDOR_MODULE := true
+LOCAL_MODULE_TAGS := optional
+include $(BUILD_EXECUTABLE)
+
+include $(LOCAL_PATH)/ta/Android.mk

--- a/sha/CMakeLists.txt
+++ b/sha/CMakeLists.txt
@@ -1,0 +1,13 @@
+project (optee_example_sha C)
+
+set (SRC host/main.c)
+
+add_executable (${PROJECT_NAME} ${SRC})
+
+target_include_directories(${PROJECT_NAME}
+			   PRIVATE ta/include
+			   PRIVATE include)
+
+target_link_libraries (${PROJECT_NAME} PRIVATE teec)
+
+install (TARGETS ${PROJECT_NAME} DESTINATION ${CMAKE_INSTALL_BINDIR})

--- a/sha/Makefile
+++ b/sha/Makefile
@@ -1,0 +1,15 @@
+export V ?= 0
+
+# If _HOST or _TA specific compilers are not specified, then use CROSS_COMPILE
+HOST_CROSS_COMPILE ?= $(CROSS_COMPILE)
+TA_CROSS_COMPILE ?= $(CROSS_COMPILE)
+
+.PHONY: all
+all:
+	$(MAKE) -C host CROSS_COMPILE="$(HOST_CROSS_COMPILE)" --no-builtin-variables
+	$(MAKE) -C ta CROSS_COMPILE="$(TA_CROSS_COMPILE)" LDFLAGS=""
+
+.PHONY: clean
+clean:
+	$(MAKE) -C host clean
+	$(MAKE) -C ta clean

--- a/sha/host/Makefile
+++ b/sha/host/Makefile
@@ -1,0 +1,28 @@
+CC      ?= $(CROSS_COMPILE)gcc
+LD      ?= $(CROSS_COMPILE)ld
+AR      ?= $(CROSS_COMPILE)ar
+NM      ?= $(CROSS_COMPILE)nm
+OBJCOPY ?= $(CROSS_COMPILE)objcopy
+OBJDUMP ?= $(CROSS_COMPILE)objdump
+READELF ?= $(CROSS_COMPILE)readelf
+
+OBJS = main.o
+
+CFLAGS += -Wall -I../ta/include -I./include
+CFLAGS += -I$(TEEC_EXPORT)/include
+LDADD += -lteec -L$(TEEC_EXPORT)/lib
+
+BINARY = optee_example_sha
+
+.PHONY: all
+all: $(BINARY)
+
+$(BINARY): $(OBJS)
+	$(CC) $(LDFLAGS) -o $@ $< $(LDADD)
+
+.PHONY: clean
+clean:
+	rm -f $(OBJS) $(BINARY)
+
+%.o: %.c
+	$(CC) $(CFLAGS) -c $< -o $@

--- a/sha/host/main.c
+++ b/sha/host/main.c
@@ -1,0 +1,359 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+ */
+
+#include <err.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+/* OP-TEE TEE client API (built by optee_client) */
+#include <tee_client_api.h>
+
+/* For the UUID (found in the TA's h-file(s)) */
+#include <sha_ta.h>
+
+/* Algo Type */
+#define SHA_HMAC	0
+#define BASE_SHA        1
+
+/* TEE resources */
+struct test_ctx {
+	TEEC_Context ctx;
+	TEEC_Session sess;
+	uint32_t algo_num;
+};
+
+static void prepare_tee_session(struct test_ctx *ctx)
+{
+	TEEC_UUID uuid = TA_SHA_UUID;
+	uint32_t origin;
+	TEEC_Result res;
+
+	/* Initialize a context connecting us to the TEE */
+	res = TEEC_InitializeContext(NULL, &ctx->ctx);
+	if (res != TEEC_SUCCESS)
+		errx(1, "TEEC_InitializeContext failed with code 0x%x", res);
+
+	/* Open a session with the TA */
+	res = TEEC_OpenSession(&ctx->ctx, &ctx->sess, &uuid,
+			       TEEC_LOGIN_PUBLIC, NULL, NULL, &origin);
+	if (res != TEEC_SUCCESS)
+		errx(1, "TEEC_Opensession failed with code 0x%x origin 0x%x",
+			res, origin);
+}
+
+static void terminate_tee_session(struct test_ctx *ctx)
+{
+	TEEC_CloseSession(&ctx->sess);
+	TEEC_FinalizeContext(&ctx->ctx);
+}
+
+static void usage(int argc, char *argv[])
+{
+	fprintf(stderr, "%s: optee_example_sha <string to process> <algo name>\n",
+		__func__);
+	fprintf(stderr, "<algo_name>: algorithm name. Supported values are:\n");
+	fprintf(stderr, "HMAC_SHA1, HMAC_SHA224, HMAC_SHA256, HMAC_SHA384, HMAC_SHA512\n");
+	fprintf(stderr, "AES_CMAC\n");
+	fprintf(stderr, "SHA1, SHA224, SHA256, SHA384, SHA512\n");
+	fprintf(stderr, "SHA3_224, SHA3_256, SHA3_384, SHA3_512\n");
+	fprintf(stderr, "SHAKE128, SHAKE256\n");
+	exit(1);
+}
+
+static void compute_digest(struct test_ctx *ctx, void *message, size_t msg_len,
+		    void *digest, size_t *digest_len)
+{
+	TEEC_Operation op = {0};
+	uint32_t origin = 0;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
+
+	op.paramTypes = TEEC_PARAM_TYPES(TEEC_MEMREF_TEMP_INPUT,
+					 TEEC_MEMREF_TEMP_OUTPUT,
+					 TEEC_VALUE_INPUT,
+					 TEEC_NONE);
+
+	op.params[0].tmpref.buffer = message;
+	op.params[0].tmpref.size = msg_len;
+	op.params[1].tmpref.buffer = digest;
+	op.params[1].tmpref.size = *digest_len;
+	op.params[2].value.a = ctx->algo_num;
+
+	res = TEEC_InvokeCommand(&ctx->sess, TA_SHA_CMD_COMPUTE_DIGEST, &op,
+				 &origin);
+
+	*digest_len = op.params[1].tmpref.size;
+
+	if (res != TEEC_SUCCESS) {
+		errx(1, "TEEC_InvokeCommand(COMPUTE DIGEST) failed 0x%x origin 0x%x",
+		     res, origin);
+	}
+}
+
+static void prepare_hmac_sha(struct test_ctx *ctx, size_t key_size,
+		      enum ta_sha_object_type obj_type)
+{
+	TEEC_Operation op = {0};
+	uint32_t origin = 0;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
+
+	op.paramTypes = TEEC_PARAM_TYPES(TEEC_VALUE_INPUT,
+					 TEEC_VALUE_INPUT,
+					 TEEC_VALUE_INPUT,
+					 TEEC_NONE);
+
+	op.params[0].value.a = ctx->algo_num;
+	op.params[1].value.a = key_size;
+	op.params[2].value.a = (uint32_t)obj_type;
+
+	res = TEEC_InvokeCommand(&ctx->sess, TA_SHA_CMD_PREPARE,
+				 &op, &origin);
+	if (res != TEEC_SUCCESS)
+		errx(1, "TEEC_InvokeCommand(PREPARE) failed 0x%x origin 0x%x",
+			res, origin);
+}
+
+static void set_key(struct test_ctx *ctx, char *key, size_t key_sz)
+{
+	TEEC_Operation op = {0};
+	uint32_t origin = 0;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
+
+	op.paramTypes = TEEC_PARAM_TYPES(TEEC_MEMREF_TEMP_INPUT,
+					 TEEC_NONE, TEEC_NONE, TEEC_NONE);
+
+	op.params[0].tmpref.buffer = key;
+	op.params[0].tmpref.size = key_sz;
+
+	res = TEEC_InvokeCommand(&ctx->sess, TA_SHA_CMD_SET_KEY,
+				 &op, &origin);
+	if (res != TEEC_SUCCESS)
+		errx(1, "TEEC_InvokeCommand(SET_KEY) failed 0x%x origin 0x%x",
+			res, origin);
+}
+
+static void set_iv(struct test_ctx *ctx, char *iv, size_t iv_sz)
+{
+	TEEC_Operation op = {0};
+	uint32_t origin = 0;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
+
+	op.paramTypes = TEEC_PARAM_TYPES(TEEC_MEMREF_TEMP_INPUT,
+					  TEEC_NONE, TEEC_NONE, TEEC_NONE);
+	op.params[0].tmpref.buffer = iv;
+	op.params[0].tmpref.size = iv_sz;
+
+	res = TEEC_InvokeCommand(&ctx->sess, TA_SHA_CMD_SET_IV,
+				 &op, &origin);
+	if (res != TEEC_SUCCESS)
+		errx(1, "TEEC_InvokeCommand(SET_IV) failed 0x%x origin 0x%x",
+			res, origin);
+}
+
+static void sha_update_ops(struct test_ctx *ctx, void *message, size_t message_sz,
+		    void *hmac_buff, size_t *hmac_sz)
+{
+	TEEC_Operation op = {0};
+	uint32_t origin = 0;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
+
+	op.paramTypes = TEEC_PARAM_TYPES(TEEC_MEMREF_TEMP_INPUT,
+					 TEEC_MEMREF_TEMP_OUTPUT,
+					 TEEC_NONE, TEEC_NONE);
+
+	op.params[0].tmpref.buffer = message;
+	op.params[0].tmpref.size = message_sz;
+	op.params[1].tmpref.buffer = hmac_buff;
+	op.params[1].tmpref.size = *hmac_sz;
+
+	res = TEEC_InvokeCommand(&ctx->sess, TA_SHA_CMD_COMPUTE_MAC, &op,
+				 &origin);
+
+	*hmac_sz = op.params[1].tmpref.size;
+
+	if (res != TEEC_SUCCESS) {
+		errx(1, "TEEC_InvokeCommand(SHA_OPS) failed 0x%x origin 0x%x",
+		     res, origin);
+	}
+}
+
+static TEEC_Result compare_hmac_sha(struct test_ctx *ctx, void *message,
+				    size_t message_sz, void *hmac_buff,
+				    size_t *hmac_sz)
+{
+	TEEC_Operation op = {0};
+	uint32_t origin = 0;
+
+	op.paramTypes = TEEC_PARAM_TYPES(TEEC_MEMREF_TEMP_INPUT,
+					 TEEC_MEMREF_TEMP_INPUT,
+					 TEEC_NONE, TEEC_NONE);
+
+	op.params[0].tmpref.buffer = message;
+	op.params[0].tmpref.size = message_sz;
+	op.params[1].tmpref.buffer = hmac_buff;
+	op.params[1].tmpref.size = *hmac_sz;
+
+	return TEEC_InvokeCommand(&ctx->sess, TA_SHA_CMD_COMPARE_MAC, &op,
+				  &origin);
+}
+
+int main(int argc, char *argv[])
+{
+	struct test_ctx ctx = {0};
+	size_t key_size;
+	void *message = NULL;
+	size_t message_sz = 0;
+	char buff[64] = {0};
+	size_t buff_sz = sizeof(buff);
+	char *algo = NULL;
+	enum ta_sha_object_type obj_type;
+	uint32_t algo_type;
+	TEEC_Result res = TEEC_ERROR_GENERIC;
+
+	if (argc < 2 || argc > 3) {
+		warnx("Unexpected number of arguments %d (expected 2)",
+		      argc - 1);
+		usage(argc, argv);
+	}
+
+	message = argv[1];
+	message_sz = strlen(argv[1]);
+
+	if (argc > 2) {
+		algo = argv[2];
+		printf("%s algo selected\n", algo);
+		if (strcmp(algo, "HMAC_SHA256") == 0) {
+			ctx.algo_num = TEE_ALG_HMAC_SHA256;
+			obj_type = TA_SHA_OBJ_TYPE_HMAC_SHA256;
+			key_size = 128; /* 128 bytes */
+			algo_type = SHA_HMAC;
+		} else if (strcmp(algo, "HMAC_SHA1") == 0) {
+			ctx.algo_num = TEE_ALG_HMAC_SHA1;
+			obj_type = TA_SHA_OBJ_TYPE_HMAC_SHA1;
+			key_size = 64; /* 64 bytes */
+			algo_type = SHA_HMAC;
+		} else if (strcmp(algo, "HMAC_SHA224") == 0) {
+			ctx.algo_num = TEE_ALG_HMAC_SHA224;
+			obj_type = TA_SHA_OBJ_TYPE_HMAC_SHA224;
+			key_size = 64; /* 64 bytes */
+			algo_type = SHA_HMAC;
+		} else if (strcmp(algo, "HMAC_SHA384") == 0) {
+			ctx.algo_num = TEE_ALG_HMAC_SHA384;
+			obj_type = TA_SHA_OBJ_TYPE_HMAC_SHA384;
+			key_size = 128; /* 128 bytes */
+			algo_type = SHA_HMAC;
+		} else if (strcmp(algo, "HMAC_SHA512") == 0) {
+			ctx.algo_num = TEE_ALG_HMAC_SHA512;
+			obj_type = TA_SHA_OBJ_TYPE_HMAC_SHA512;
+			key_size = 128; /* 128 bytes */
+			algo_type = SHA_HMAC;
+		} else if (strcmp(algo, "AES_CMAC") == 0) {
+			ctx.algo_num = TEE_ALG_AES_CMAC;
+			obj_type = TA_SHA_OBJ_TYPE_AES;
+			key_size = 16; /* 16 bytes */
+			algo_type = SHA_HMAC;
+		} else if (strcmp(algo, "SHA1") == 0) {
+			ctx.algo_num = TEE_ALG_SHA1;
+			algo_type = BASE_SHA;
+		} else if (strcmp(algo, "SHA224") == 0) {
+			ctx.algo_num = TEE_ALG_SHA224;
+			algo_type = BASE_SHA;
+		} else if (strcmp(algo, "SHA256") == 0) {
+			ctx.algo_num = TEE_ALG_SHA256;
+			algo_type = BASE_SHA;
+		} else if (strcmp(algo, "SHA384") == 0) {
+			ctx.algo_num = TEE_ALG_SHA384;
+			algo_type = BASE_SHA;
+		} else if (strcmp(algo, "SHA512") == 0) {
+			ctx.algo_num = TEE_ALG_SHA512;
+			algo_type = BASE_SHA;
+		} else if (strcmp(algo, "SHA3_224") == 0) {
+			ctx.algo_num = TEE_ALG_SHA3_224;
+			algo_type = BASE_SHA;
+		} else if (strcmp(algo, "SHA3_256") == 0) {
+			ctx.algo_num = TEE_ALG_SHA3_256;
+			algo_type = BASE_SHA;
+		} else if (strcmp(algo, "SHA3_384") == 0) {
+			ctx.algo_num = TEE_ALG_SHA3_384;
+			algo_type = BASE_SHA;
+		} else if (strcmp(algo, "SHA3_512") == 0) {
+			ctx.algo_num = TEE_ALG_SHA3_512;
+			algo_type = BASE_SHA;
+		} else if (strcmp(algo, "SHAKE128") == 0) {
+			ctx.algo_num = TEE_ALG_SHAKE128;
+			algo_type = BASE_SHA;
+		} else if (strcmp(algo, "SHAKE256") == 0) {
+			ctx.algo_num = TEE_ALG_SHAKE256;
+			algo_type = BASE_SHA;
+		} else {
+			printf("%s algo is invalid\n", algo);
+			usage(argc, argv);
+		}
+	} else {
+		printf("HMAC_SHA256 algo selected\n");
+		ctx.algo_num = TEE_ALG_HMAC_SHA256;
+		key_size = 128; /* 128 bytes */
+		obj_type = TA_SHA_OBJ_TYPE_HMAC_SHA256;
+		algo_type = SHA_HMAC;
+	}
+
+	printf("Prepare session with the TA\n");
+	prepare_tee_session(&ctx);
+
+	if (algo_type != SHA_HMAC) {
+		/* SHA digest */
+		printf("Compute digest\n");
+		compute_digest(&ctx, message, message_sz, (void *)buff,
+			       &buff_sz);
+		printf("digest: ");
+
+	} else {
+		/* SHA HMAC */
+		char key[key_size];
+
+		printf("Prepare MAC compute operation\n");
+		prepare_hmac_sha(&ctx, key_size, obj_type);
+
+		printf("Load key in TA\n");
+		memset(key, 0xa5, sizeof(key)); /* Load some dummy value */
+		set_key(&ctx, key, key_size);
+
+		printf("Reset operation in TA (provides the initial vector)\n");
+		set_iv(&ctx, NULL, 0);
+
+		printf("Compute MAC operation\n");
+		sha_update_ops(&ctx, message, message_sz, (void *)buff,
+			       &buff_sz);
+
+		printf("Prepare MAC compare operation\n");
+		prepare_hmac_sha(&ctx, key_size, obj_type);
+
+		printf("Load key in TA\n");
+		memset(key, 0xa5, sizeof(key)); /* Load some dummy value */
+		set_key(&ctx, key, key_size);
+
+		printf("Reset operation in TA (provides the initial vector)\n");
+		set_iv(&ctx, NULL, 0);
+
+		printf("Compare the MAC\n");
+		res = compare_hmac_sha(&ctx, message, message_sz,
+				       (void *)buff, &buff_sz);
+
+		if (res == TEEC_SUCCESS)
+			printf("MAC successfully matching\n");
+		else
+			printf("MAC did not match\n");
+
+		printf("MAC: ");
+	}
+
+	for (int32_t i = 0 ; i < buff_sz ; i++)
+		printf("%02x", buff[i]);
+
+	printf("\n");
+
+	terminate_tee_session(&ctx);
+	return 0;
+}

--- a/sha/ta/Android.mk
+++ b/sha/ta/Android.mk
@@ -1,0 +1,4 @@
+LOCAL_PATH := $(call my-dir)
+
+local_module := 1dc6a16b-2fba-4aa1-9519-ea8a6c8c16e5.ta
+include $(BUILD_OPTEE_MK)

--- a/sha/ta/Makefile
+++ b/sha/ta/Makefile
@@ -1,0 +1,13 @@
+CFG_TEE_TA_LOG_LEVEL ?= 4
+CFG_TA_OPTEE_CORE_API_COMPAT_1_1=y
+
+# The UUID for the Trusted Application
+BINARY=1dc6a16b-2fba-4aa1-9519-ea8a6c8c16e5
+
+-include $(TA_DEV_KIT_DIR)/mk/ta_dev_kit.mk
+
+ifeq ($(wildcard $(TA_DEV_KIT_DIR)/mk/ta_dev_kit.mk), )
+clean:
+	@echo 'Note: $$(TA_DEV_KIT_DIR)/mk/ta_dev_kit.mk not found, cannot clean TA'
+	@echo 'Note: TA_DEV_KIT_DIR=$(TA_DEV_KIT_DIR)'
+endif

--- a/sha/ta/include/sha_ta.h
+++ b/sha/ta/include/sha_ta.h
@@ -1,0 +1,97 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+ */
+
+#ifndef __SHA_TA_H__
+#define __SHA_TA_H__
+
+/* UUID of the SHA example trusted application */
+#define TA_SHA_UUID \
+	{ 0x1dc6a16b, 0x2fba, 0x4aa1, \
+		{ 0x95, 0x19, 0xea, 0x8a, 0x6c, 0x8c, 0x16, 0xe5 } }
+
+/*
+ * TA_SHA_CMD_PREPARE - Allocate resources for the MAC operation
+ * param[0] (value) a: TEE ID of the algo to use (TEE_ALG_xxx), b: unused
+ * param[1] (value) a: key size in bytes, b: unused
+ * param[2] (value) a: obj_type, b: unused
+ * param[3] unused
+ */
+#define TA_SHA_CMD_PREPARE		0
+
+/* SHA Algo */
+#define TEE_ALG_SHA1			0x50000002
+#define TEE_ALG_SHA224                  0x50000003
+#define TEE_ALG_SHA256                  0x50000004
+#define TEE_ALG_SHA384                  0x50000005
+#define TEE_ALG_SHA512                  0x50000006
+#define TEE_ALG_SHA3_224                0x50000008
+#define TEE_ALG_SHA3_256                0x50000009
+#define TEE_ALG_SHA3_384                0x5000000A
+#define TEE_ALG_SHA3_512                0x5000000B
+#define TEE_ALG_HMAC_SHA1               0x30000002
+#define TEE_ALG_HMAC_SHA224             0x30000003
+#define TEE_ALG_HMAC_SHA256             0x30000004
+#define TEE_ALG_HMAC_SHA384             0x30000005
+#define TEE_ALG_HMAC_SHA512             0x30000006
+#define TEE_ALG_SHAKE128                0x50000101
+#define TEE_ALG_SHAKE256                0x50000102
+#define TEE_ALG_AES_CMAC                0x30000610
+
+/* Object types */
+enum ta_sha_object_type {
+	TA_SHA_OBJ_TYPE_HMAC_SHA256 = 0,
+	TA_SHA_OBJ_TYPE_HMAC_SHA1 = 1,
+	TA_SHA_OBJ_TYPE_HMAC_SHA224 = 2,
+	TA_SHA_OBJ_TYPE_HMAC_SHA384 = 3,
+	TA_SHA_OBJ_TYPE_HMAC_SHA512 = 4,
+	TA_SHA_OBJ_TYPE_AES = 5,
+};
+
+/*
+ * TA_SHA_CMD_SET_KEY - Allocate resources for the MAC operation
+ * param[0] (memref/intput) key data, size shall equal key length
+ * param[1] unused
+ * param[2] unused
+ * param[3] unused
+ */
+#define TA_SHA_CMD_SET_KEY		1
+
+/*
+ * TA_SHA_CMD_SET_IV - reset IV
+ * param[0] (memref/input) initial vector, size shall equal block length
+ * param[1] unused
+ * param[2] unused
+ * param[3] unused
+ */
+#define TA_SHA_CMD_SET_IV		2
+
+/*
+ * TA_SHA_CMD_COMPUTE_MAC - Process MAC operation
+ * param[0] (memref/input) message, message size
+ * param[1] (memref/output) MAC buffer, buffer size
+ * param[2] unused
+ * param[3] unused
+ */
+#define TA_SHA_CMD_COMPUTE_MAC		3
+
+/*
+ * TA_SHA_CMD_COMPARE_MAC - compare MAC values
+ * param[0] (memref/input) message, message size
+ * param[1] (memref/input) Expected MAC data
+ * param[2] unused
+ * param[3] unused
+ */
+#define TA_SHA_CMD_COMPARE_MAC		4
+
+/*
+ * TA_SHA_CMD_COMPUTE_DIGEST - Computing the digest
+ * param[0] (memref/input) message, message size
+ * param[1] (memref/output) digest buffer, buffer size
+ * param[2] (value/input) a:TA_ALG_SHA*, b: unused
+ * param[3] unused
+ */
+#define TA_SHA_CMD_COMPUTE_DIGEST	5
+
+#endif /* __SHA_TA_H */

--- a/sha/ta/sha_ta.c
+++ b/sha/ta/sha_ta.c
@@ -1,0 +1,473 @@
+// SPDX-License-Identifier: BSD-2-Clause
+/*
+ * Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+ */
+
+#include <inttypes.h>
+
+#include <tee_internal_api.h>
+#include <tee_internal_api_extensions.h>
+
+#include <sha_ta.h>
+
+struct sha_hmac_algo {
+	uint32_t algo;			/* SHA flavour */
+	uint32_t mode;			/* Encode or decode */
+	uint32_t key_size;		/* SHA key size in byte */
+	TEE_OperationHandle op_handle;	/* SHA operation */
+	TEE_ObjectHandle key_handle;	/* transient object to load the key */
+};
+
+static TEE_Result ta2tee_obj_type(uint32_t param, uint32_t *tee_obj_type)
+{
+	enum ta_sha_object_type obj_type = (enum ta_sha_object_type)param;
+
+	switch (obj_type) {
+	case TA_SHA_OBJ_TYPE_HMAC_SHA256:
+		*tee_obj_type = TEE_TYPE_HMAC_SHA256;
+		return TEE_SUCCESS;
+	case TA_SHA_OBJ_TYPE_HMAC_SHA1:
+		*tee_obj_type = TEE_TYPE_HMAC_SHA1;
+		return TEE_SUCCESS;
+	case TA_SHA_OBJ_TYPE_HMAC_SHA224:
+		*tee_obj_type = TEE_TYPE_HMAC_SHA224;
+		return TEE_SUCCESS;
+	case TA_SHA_OBJ_TYPE_HMAC_SHA384:
+		*tee_obj_type = TEE_TYPE_HMAC_SHA384;
+		return TEE_SUCCESS;
+	case TA_SHA_OBJ_TYPE_HMAC_SHA512:
+		*tee_obj_type = TEE_TYPE_HMAC_SHA512;
+		return TEE_SUCCESS;
+	case TA_SHA_OBJ_TYPE_AES:
+		*tee_obj_type = TEE_TYPE_AES;
+		return TEE_SUCCESS;
+	default:
+		EMSG("Invalid mode %"PRIu32, param);
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+}
+
+static TEE_Result compute_digest(void *session, uint32_t param_types,
+				 TEE_Param params[4])
+{
+	struct sha_hmac_algo *sess = NULL;
+	TEE_Result res = TEE_ERROR_OUT_OF_MEMORY;
+	void *msg = NULL;
+	size_t msg_len = 0;
+	uint32_t digest_len = 0;
+	void *b2 = NULL;
+
+	const uint32_t exp_param_types =
+		TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
+				TEE_PARAM_TYPE_MEMREF_OUTPUT,
+				TEE_PARAM_TYPE_VALUE_INPUT,
+				TEE_PARAM_TYPE_NONE);
+
+	if (param_types != exp_param_types)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	msg = params[0].memref.buffer;
+	msg_len = params[0].memref.size;
+	digest_len = params[1].memref.size;
+
+	DMSG("Session %p: get compute digest", session);
+	sess = session;
+
+	if (params[1].memref.buffer && params[1].memref.size) {
+		b2 = TEE_Malloc(params[1].memref.size, 0);
+		if (!b2)
+			goto out;
+	}
+
+	sess->algo = params[2].value.a;
+
+	res = TEE_AllocateOperation(&sess->op_handle,
+				    sess->algo,
+				    TEE_MODE_DIGEST, 0);
+	if (res != TEE_SUCCESS)
+		goto out;
+
+	TEE_DigestUpdate(sess->op_handle, msg, msg_len);
+
+	res = TEE_DigestDoFinal(sess->op_handle, NULL, 0, b2, &digest_len);
+	if (res == TEE_SUCCESS)
+		TEE_MemMove(params[1].memref.buffer, b2, digest_len);
+
+	params[1].memref.size = digest_len;
+
+out:
+	TEE_Free(b2);
+	return res;
+}
+
+static TEE_Result alloc_resources(void *session, uint32_t param_types,
+				  TEE_Param params[4])
+{
+	struct sha_hmac_algo *sess = NULL;
+	TEE_Attribute attr = {0};
+	TEE_Result res = TEE_ERROR_GENERIC;
+	char *key = NULL;
+	uint32_t tee_obj_type = TEE_TYPE_HMAC_SHA256;
+
+	const uint32_t exp_param_types =
+		TEE_PARAM_TYPES(TEE_PARAM_TYPE_VALUE_INPUT,
+				TEE_PARAM_TYPE_VALUE_INPUT,
+				TEE_PARAM_TYPE_VALUE_INPUT,
+				TEE_PARAM_TYPE_NONE);
+
+	/* Get context from session ID */
+	DMSG("Session %p: get resources", session);
+	sess = session;
+
+	/* Safely get the invocation parameters */
+	if (param_types != exp_param_types)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	sess->algo = params[0].value.a;
+
+	res = ta2tee_obj_type(params[2].value.a, &tee_obj_type);
+	if (res != TEE_SUCCESS)
+		return res;
+
+	sess->key_size = params[1].value.a;
+	sess->mode = TEE_MODE_MAC;
+
+	/* Free potential previous operation */
+	if (sess->op_handle != TEE_HANDLE_NULL) {
+		TEE_FreeOperation(sess->op_handle);
+		sess->op_handle = TEE_HANDLE_NULL;
+	}
+
+	/* Allocate operation: SHA, mode and size from params */
+	res = TEE_AllocateOperation(&sess->op_handle,
+				    sess->algo,
+				    sess->mode,
+				    sess->key_size * 8);
+	if (res != TEE_SUCCESS) {
+		EMSG("Failed to allocate operation");
+		goto err;
+	}
+
+	/* Free potential previous transient object */
+	if (sess->key_handle != TEE_HANDLE_NULL) {
+		TEE_FreeTransientObject(sess->key_handle);
+		sess->key_handle = TEE_HANDLE_NULL;
+	}
+
+	/* Allocate transient object according to target key size */
+	res = TEE_AllocateTransientObject(tee_obj_type,
+					  sess->key_size * 8,
+					  &sess->key_handle);
+	if (res != TEE_SUCCESS) {
+		EMSG("Failed to allocate transient object");
+		goto err;
+	}
+
+	key = TEE_Malloc(sess->key_size, 0);
+	if (!key) {
+		res = TEE_ERROR_OUT_OF_MEMORY;
+		goto err;
+	}
+
+	TEE_InitRefAttribute(&attr, TEE_ATTR_SECRET_VALUE, key, sess->key_size);
+
+	res = TEE_PopulateTransientObject(sess->key_handle, &attr, 1);
+	TEE_Free(key);
+	if (res != TEE_SUCCESS) {
+		EMSG("TEE_PopulateTransientObject failed, %#"PRIx32, res);
+		goto err;
+	}
+
+	res = TEE_SetOperationKey(sess->op_handle, sess->key_handle);
+	if (res != TEE_SUCCESS) {
+		EMSG("TEE_SetOperationKey failed %#"PRIx32, res);
+		goto err;
+	}
+
+	return TEE_SUCCESS;
+
+err:
+	TEE_FreeOperation(sess->op_handle);
+	sess->op_handle = TEE_HANDLE_NULL;
+
+	TEE_FreeTransientObject(sess->key_handle);
+	sess->key_handle = TEE_HANDLE_NULL;
+
+	return res;
+}
+
+/*
+ * Process command TA_SHA_CMD_SET_KEY. API in sha_ta.h
+ */
+static TEE_Result set_sha_key(void *session, uint32_t param_types,
+				TEE_Param params[4])
+{
+	struct sha_hmac_algo *sess = NULL;
+	TEE_Attribute attr = {0};
+	TEE_Result res = TEE_ERROR_GENERIC;
+	uint32_t key_sz = 0;
+	char *key = NULL;
+
+	const uint32_t exp_param_types =
+		TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
+				TEE_PARAM_TYPE_NONE,
+				TEE_PARAM_TYPE_NONE,
+				TEE_PARAM_TYPE_NONE);
+
+	/* Get ciphering context from session ID */
+	DMSG("Session %p: load key material", session);
+	sess = session;
+
+	if (sess->key_handle == TEE_HANDLE_NULL ||
+	    sess->op_handle == TEE_HANDLE_NULL) {
+		EMSG("Operation not properly initialized.");
+		return TEE_ERROR_BAD_STATE;
+	}
+
+	/* Safely get the invocation parameters */
+	if (param_types != exp_param_types)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	key = params[0].memref.buffer;
+	key_sz = params[0].memref.size;
+
+	if (key_sz != sess->key_size) {
+		EMSG("Wrong key size %" PRIu32 ", expect %" PRIu32 " bytes",
+		     key_sz, sess->key_size);
+		return TEE_ERROR_BAD_PARAMETERS;
+	}
+
+	/*
+	 * Load the key material into the configured operation
+	 * - create a secret key attribute with the key material
+	 *   TEE_InitRefAttribute()
+	 * - reset transient object and load attribute data
+	 *   TEE_ResetTransientObject()
+	 *   TEE_PopulateTransientObject()
+	 * - load the key (transient object) into the ciphering operation
+	 *   TEE_SetOperationKey()
+	 *
+	 * TEE_SetOperationKey() requires operation to be in "initial state".
+	 * We can use TEE_ResetOperation() to reset the operation but this
+	 * API cannot be used on operation with key(s) not yet set. Hence,
+	 * when allocating the operation handle, we load a dummy key.
+	 * Thus, set_key sequence always reset then set key on operation.
+	 */
+
+	TEE_InitRefAttribute(&attr, TEE_ATTR_SECRET_VALUE, key, key_sz);
+
+	TEE_ResetTransientObject(sess->key_handle);
+	res = TEE_PopulateTransientObject(sess->key_handle, &attr, 1);
+	if (res != TEE_SUCCESS) {
+		EMSG("TEE_PopulateTransientObject failed, %#"PRIx32, res);
+		return res;
+	}
+
+	TEE_ResetOperation(sess->op_handle);
+	res = TEE_SetOperationKey(sess->op_handle, sess->key_handle);
+	if (res != TEE_SUCCESS) {
+		EMSG("TEE_SetOperationKey failed %#"PRIx32, res);
+		return res;
+	}
+
+	return res;
+}
+
+/*
+ * Process command TA_SHA_CMD_SET_IV. API in sha_ta.h
+ */
+static TEE_Result reset_sha_iv(void *session, uint32_t param_types,
+				TEE_Param params[4])
+{
+	struct sha_hmac_algo *sess = NULL;
+	size_t iv_sz = 0;
+	char *iv = NULL;
+
+	const uint32_t exp_param_types =
+		TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
+				TEE_PARAM_TYPE_NONE,
+				TEE_PARAM_TYPE_NONE,
+				TEE_PARAM_TYPE_NONE);
+
+	/* Get context from session ID */
+	DMSG("Session %p: reset initial vector", session);
+	sess = session;
+
+	if (sess->op_handle == TEE_HANDLE_NULL) {
+		EMSG("Operation not properly initialized.");
+		return TEE_ERROR_BAD_STATE;
+	}
+
+	/* Safely get the invocation parameters */
+	if (param_types != exp_param_types)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	iv = params[0].memref.buffer;
+	iv_sz = params[0].memref.size;
+
+	/*
+	 * Init operation with the initialization vector.
+	 */
+	TEE_MACInit(sess->op_handle, iv, iv_sz);
+
+	return TEE_SUCCESS;
+}
+
+static TEE_Result sha_update_op(void *session, uint32_t param_types,
+				TEE_Param params[4])
+{
+	struct sha_hmac_algo *sess = NULL;
+	TEE_Result res = TEE_ERROR_OUT_OF_MEMORY;
+	void *message = NULL;
+	size_t message_sz = 0;
+	uint32_t hmac_len = 0;
+	void *b2 = NULL;
+
+	const uint32_t exp_param_types =
+		TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
+				TEE_PARAM_TYPE_MEMREF_OUTPUT,
+				TEE_PARAM_TYPE_NONE,
+				TEE_PARAM_TYPE_NONE);
+
+	DMSG("Session %p: sha update operation", session);
+	sess = session;
+
+	if (sess->op_handle == TEE_HANDLE_NULL) {
+		EMSG("Operation not properly initialized.");
+		return TEE_ERROR_BAD_STATE;
+	}
+
+	if (param_types != exp_param_types)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	message = params[0].memref.buffer;
+	message_sz = params[0].memref.size;
+	hmac_len = (uint32_t)params[1].memref.size;
+
+	if (params[1].memref.buffer && params[1].memref.size) {
+		b2 = TEE_Malloc(params[1].memref.size, 0);
+		if (!b2)
+			goto out;
+	}
+
+	TEE_MACUpdate(sess->op_handle, message, message_sz);
+
+	res = TEE_MACComputeFinal(sess->op_handle, message, message_sz,
+				  b2, &hmac_len);
+
+	if (res == TEE_SUCCESS)
+		TEE_MemMove(params[1].memref.buffer, b2, hmac_len);
+
+	params[1].memref.size = hmac_len;
+
+out:
+	TEE_Free(b2);
+	return res;
+}
+
+static TEE_Result compare_hmac_sha_algo(void *session, uint32_t param_types,
+					TEE_Param params[4])
+{
+	struct sha_hmac_algo *sess = NULL;
+	void *message = NULL;
+	size_t message_sz = 0;
+	void *hmac_buff = NULL;
+	uint32_t hmac_len = 0;
+
+	const uint32_t exp_param_types =
+		TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
+				TEE_PARAM_TYPE_MEMREF_INPUT,
+				TEE_PARAM_TYPE_NONE,
+				TEE_PARAM_TYPE_NONE);
+
+	DMSG("Session %p: Compare HMAC SHA", session);
+	sess = session;
+
+	if (sess->op_handle == TEE_HANDLE_NULL) {
+		EMSG("Operation not properly initialized.");
+		return TEE_ERROR_BAD_STATE;
+	}
+
+	if (param_types != exp_param_types)
+		return TEE_ERROR_BAD_PARAMETERS;
+
+	message = params[0].memref.buffer;
+	message_sz = params[0].memref.size;
+	hmac_buff = params[1].memref.buffer;
+	hmac_len = (uint32_t)params[1].memref.size;
+
+	TEE_MACUpdate(sess->op_handle, message, message_sz);
+
+	return TEE_MACCompareFinal(sess->op_handle, message, message_sz,
+				   hmac_buff, hmac_len);
+}
+
+TEE_Result TA_CreateEntryPoint(void)
+{
+	/* Nothing to do */
+	return TEE_SUCCESS;
+}
+
+void TA_DestroyEntryPoint(void)
+{
+	/* Nothing to do */
+}
+
+TEE_Result TA_OpenSessionEntryPoint(uint32_t __unused param_types,
+					TEE_Param __unused params[4],
+					void **session)
+{
+	/*
+	 * Allocate and init for the session.
+	 * The address of the structure is used as session ID for
+	 * the client.
+	 */
+	struct sha_hmac_algo *sess = TEE_Malloc(sizeof(*sess), 0);
+
+	if (!sess)
+		return TEE_ERROR_OUT_OF_MEMORY;
+
+	sess->key_handle = TEE_HANDLE_NULL;
+	sess->op_handle = TEE_HANDLE_NULL;
+
+	*session = sess;
+	DMSG("Session %p: newly allocated", *session);
+
+	return TEE_SUCCESS;
+}
+
+void TA_CloseSessionEntryPoint(void *session)
+{
+	/* Get context from session ID */
+	DMSG("Session %p: release session", session);
+	struct sha_hmac_algo *sess = session;
+
+	/* Release the session resources */
+	TEE_FreeTransientObject(sess->key_handle);
+	TEE_FreeOperation(sess->op_handle);
+	TEE_Free(sess);
+}
+
+TEE_Result TA_InvokeCommandEntryPoint(void *session,
+					uint32_t cmd,
+					uint32_t param_types,
+					TEE_Param params[4])
+{
+	switch (cmd) {
+	case TA_SHA_CMD_PREPARE:
+		return alloc_resources(session, param_types, params);
+	case TA_SHA_CMD_SET_KEY:
+		return set_sha_key(session, param_types, params);
+	case TA_SHA_CMD_SET_IV:
+		return reset_sha_iv(session, param_types, params);
+	case TA_SHA_CMD_COMPUTE_MAC:
+		return sha_update_op(session, param_types, params);
+	case TA_SHA_CMD_COMPARE_MAC:
+		return compare_hmac_sha_algo(session, param_types, params);
+	case TA_SHA_CMD_COMPUTE_DIGEST:
+		return compute_digest(session, param_types, params);
+	default:
+		EMSG("Command ID 0x%"PRIx32" is not supported", cmd);
+		return TEE_ERROR_NOT_SUPPORTED;
+	}
+}

--- a/sha/ta/sub.mk
+++ b/sha/ta/sub.mk
@@ -1,0 +1,2 @@
+global-incdirs-y += include
+srcs-y += sha_ta.c

--- a/sha/ta/user_ta_header_defines.h
+++ b/sha/ta/user_ta_header_defines.h
@@ -1,0 +1,31 @@
+/* SPDX-License-Identifier: BSD-2-Clause */
+/*
+ * Copyright (c) 2025, Advanced Micro Devices, Inc. All rights reserved.
+ */
+
+/*
+ * The name of this file must not be modified
+ */
+
+#ifndef USER_TA_HEADER_DEFINES_H
+#define USER_TA_HEADER_DEFINES_H
+
+#include <sha_ta.h>
+
+#define TA_UUID				TA_SHA_UUID
+
+#define TA_FLAGS			0
+
+/* Provisioned stack size */
+#define TA_STACK_SIZE			(2 * 1024)
+
+/* Provisioned heap size for TEE_Malloc() and friends */
+#define TA_DATA_SIZE			(32 * 1024)
+
+/* The gpd.ta.version property */
+#define TA_VERSION	"1.0"
+
+/* The gpd.ta.description property */
+#define TA_DESCRIPTION	"Example of TA using an SHA sequence"
+
+#endif /*USER_TA_HEADER_DEFINES_H*/


### PR DESCRIPTION
Add new example for MAC and digest algorithms

The user can now invoke:
optee_example_sha <string> <algo>

<algo>: algorithm name. Supported values for algo are:
- TA_ALGO_HMAC_SHA256 (default)
- TA_ALGO_HMAC_SHA1
- TA_ALGO_HMAC_SHA224
- TA_ALGO_HMAC_SHA384
- TA_ALGO_HMAC_SHA512
- TA_ALG_SHA1
- TA_ALG_SHA224
- TA_ALG_SHA256
- TA_ALG_SHA384
- TA_ALG_SHA512
- TA_ALG_SHA3_224
- TA_ALG_SHA3_256
- TA_ALG_SHA3_384
- TA_ALG_SHA3_512
- TA_ALG_SHAKE128
- TA_ALG_SHAKE256