### PR TITLE
Makefile: Avoid variable override

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ clean: examples-clean prepare-for-rootfs-clean
 
 examples:
 	@for example in $(EXAMPLE_LIST); do \
-		$(MAKE) -C $$example CROSS_COMPILE="$(HOST_CROSS_COMPILE)" || exit 1; \
+		$(MAKE) -C $$example || exit 1; \
 	done
 
 examples-clean:


### PR DESCRIPTION
When CROSS_COMPILE is set in the environment / command line, we should not directly pass it to the subshell, otherwise it's evaluated to an empty string.