### PR TITLE
sign_verify: fix size_t type trace specifier

### DIFF
--- a/sign_verify/host/main.c
+++ b/sign_verify/host/main.c
@@ -59,7 +59,7 @@ static void get_args(int argc, char *argv[], size_t *key_size,
 	}
 
 	*key_size = ks;
-	printf("Key size: %lu\n", *key_size);
+	printf("Key size: %zu\n", *key_size);
 
 	if (argc > 2) {
 		algo = argv[2];


### PR DESCRIPTION
Fix build warning/error on a printed size_t type variable as shown below:

```
.../out-br/build/optee_examples_ext-1.0/sign_verify/host/main.c: In function ‘get_args’: .../out-br/build/optee_examples_ext-1.0/sign_verify/host/main.c:62:29: warning: format ‘%lu’ expects argument of type ‘long unsigned int’, but argument 2 has type ‘size_t’ {aka ‘unsigned int’} [-Wformat=]
   62 |         printf("Key size: %lu\n", *key_size);
      |                           ~~^     ~~~~~~~~~
      |                             |     |
      |                             |     size_t {aka unsigned int}
      |                             long unsigned int
      |                           %u
```
Fixes: 911076b8e5ca ("sign_verify: Add dynamic algorithm selection with sign and verify support")