### PR TITLE
aes: add file input and command-line key/IV support

### DIFF
--- a/aes/host/main.c
+++ b/aes/host/main.c
@@ -5,7 +5,9 @@
  */
 
 #include <err.h>
+#include <stdbool.h>
 #include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 
 /* OP-TEE TEE client API (built by optee_client) */
@@ -13,6 +15,104 @@
 
 /* For the UUID (found in the TA's h-file(s)) */
 #include <aes_ta.h>
+
+/* Function to read file contents */
+static int read_file_contents(const char *filepath, uint8_t **buffer, size_t *size)
+{
+	FILE *f = NULL;
+	long file_size = 0;
+	uint8_t *data = NULL;
+	size_t bytes_read = 0;
+
+	f = fopen(filepath, "rb");
+	if (!f) {
+		fprintf(stderr, "Error: Cannot open file '%s'\n", filepath);
+		return -1;
+	}
+
+	/* Get file size */
+	if (fseek(f, 0, SEEK_END) != 0) {
+		fprintf(stderr, "Error: Cannot seek to end of file '%s'\n", filepath);
+		fclose(f);
+		return -1;
+	}
+
+	file_size = ftell(f);
+	if (file_size < 0) {
+		fprintf(stderr, "Error: Cannot get file size for '%s'\n", filepath);
+		fclose(f);
+		return -1;
+	}
+
+	if (file_size == 0) {
+		fprintf(stderr, "Error: File '%s' is empty\n", filepath);
+		fclose(f);
+		return -1;
+	}
+
+	if (fseek(f, 0, SEEK_SET) != 0) {
+		fprintf(stderr, "Error: Cannot rewind file '%s'\n", filepath);
+		fclose(f);
+		return -1;
+	}
+
+	/* Allocate buffer */
+	data = malloc(file_size);
+	if (!data) {
+		fprintf(stderr, "Error: Cannot allocate memory for file '%s' (%ld bytes)\n",
+			filepath, file_size);
+		fclose(f);
+		return -1;
+	}
+
+	/* Read file contents */
+	bytes_read = fread(data, 1, file_size, f);
+	if (bytes_read != (size_t)file_size) {
+		fprintf(stderr, "Error: Failed to read complete file '%s' (read %zu of %ld bytes)\n",
+			filepath, bytes_read, file_size);
+		free(data);
+		fclose(f);
+		return -1;
+	}
+
+	fclose(f);
+
+	*buffer = data;
+	*size = (size_t)file_size;
+	return 0;
+}
+
+/* Helper function to convert hex string to bytes */
+static int hex_to_bytes(const char *hex_str, uint8_t *bytes, size_t max_len)
+{
+	size_t len = strlen(hex_str);
+	size_t byte_len = 0;
+	size_t i = 0;
+
+	if (len % 2 != 0) {
+		fprintf(stderr, "Error: Hex string must have even length\n");
+		return -1;
+	}
+
+	byte_len = len / 2;
+
+	if (byte_len > max_len) {
+		fprintf(stderr, "Error: Hex string too long (max %zu bytes)\n",
+			max_len);
+		return -1;
+	}
+
+	for (i = 0; i < byte_len; i++) {
+		if (sscanf(hex_str + 2 * i, "%2hhx", &bytes[i]) != 1) {
+			fprintf(stderr,
+				"Error: Invalid hex character at position %zu\n",
+				2 * i);
+			return -1;
+		}
+	}
+
+	return (int)byte_len;
+}
 
 #define AES_TEST_BUFFER_SIZE	4096
 #define AES_TEST_KEY_SIZE	16
@@ -180,45 +280,230 @@ void auth_enc_op(struct test_ctx *ctx, uint32_t encrypt, void *in_buf, size_t
 	}
 }
 
+static void print_usage(const char *progname)
+{
+	printf("Usage: %s [options]\n\n", progname);
+	printf("Options:\n");
+	printf("  --algo <algorithm>   AES algorithm (default: TA_AES_ALGO_CTR)\n");
+	printf("                       Valid: TA_AES_ALGO_ECB, TA_AES_ALGO_CBC,\n");
+	printf("                              TA_AES_ALGO_CTR, TA_AES_ALGO_CCM,\n");
+	printf("                              TA_AES_ALGO_GCM\n\n");
+	printf("  --input-file <path>  Input file to encrypt (optional)\n\n");
+	printf("  --key <hex_string>   Key in hexadecimal (optional, uses default if not provided)\n");
+	printf("                       16 bytes = 32 hex characters\n\n");
+	printf("  --iv <hex_string>    IV/Nonce in hexadecimal (optional, uses default if not provided)\n");
+	printf("                       16 bytes for CBC/CTR/ECB, 12 bytes for CCM/GCM\n\n");
+	printf("  --help, -h           Show this help message\n\n");
+	printf("Examples:\n");
+	printf("  %s\n", progname);
+	printf("  %s --algo TA_AES_ALGO_CBC\n", progname);
+	printf("  %s --algo TA_AES_ALGO_GCM --input-file document.pdf\n", progname);
+	printf("  %s --algo TA_AES_ALGO_CTR --key a5a5... --iv 0000...\n", progname);
+	printf("  %s --input-file firmware.bin --key c3c3... --iv 1234...\n\n", progname);
+	printf("Note: --key and --iv are optional. Default key is 0xa5 pattern,\n");
+	printf("      default IV is all zeros. If no --input-file is provided,\n");
+	printf("      a default test pattern (0x5a, %d bytes) will be used.\n", AES_TEST_BUFFER_SIZE);
+}
+
 int main(int argc, char *argv[])
 {
 	struct test_ctx ctx;
 	char key[AES_TEST_KEY_SIZE];
 	char iv[AES_BLOCK_SIZE];
-	char clear[AES_TEST_BUFFER_SIZE];
-	char ciph[AES_TEST_BUFFER_SIZE];
-	char temp[AES_TEST_BUFFER_SIZE];
-	char *algo;
-	char plaintext[] = "TestCCMMessage";
-	uint8_t ciphertext[80] = {0};
-	uint8_t decrypted[80] = {0};
-	size_t ct_len = sizeof(ciphertext);
-	size_t dec_len = sizeof(decrypted);
+	static char clear[AES_TEST_BUFFER_SIZE];
+	char *algo = NULL;
+	char *input_file = NULL;
+	char *key_hex = NULL;
+	char *iv_hex = NULL;
+	uint8_t *file_buffer = NULL;
+	uint8_t *ciph = NULL;
+	uint8_t *temp = NULL;
+	uint8_t *ciphertext = NULL;
+	uint8_t *decrypted = NULL;
+	size_t ct_len = 0;
+	size_t dec_len = 0;
 	uint8_t tag[16] = {0};
 	size_t tag_len = 16;
+	size_t input_len = AES_TEST_BUFFER_SIZE;
+	size_t original_len = 0;
+	size_t iv_len = 0;
+	int i;
 
-	if (argc > 1) {
-		algo = argv[1];
-		printf("%s algo selected\n", algo);
+	/* Parse command line arguments */
+	for (i = 1; i < argc; i++) {
+		if (strcmp(argv[i], "--algo") == 0 && i + 1 < argc) {
+			algo = argv[++i];
+		} else if (strcmp(argv[i], "--input-file") == 0 && i + 1 < argc) {
+			input_file = argv[++i];
+		} else if (strcmp(argv[i], "--key") == 0 && i + 1 < argc) {
+			key_hex = argv[++i];
+		} else if (strcmp(argv[i], "--iv") == 0 && i + 1 < argc) {
+			iv_hex = argv[++i];
+		} else if (strcmp(argv[i], "--help") == 0 ||
+			   strcmp(argv[i], "-h") == 0) {
+			print_usage(argv[0]);
+			return 0;
+		} else {
+			fprintf(stderr, "Error: Unknown or incomplete option '%s'\n", argv[i]);
+			fprintf(stderr, "Use --help for usage information.\n");
+			return -1;
+		}
+	}
+
+	/* Select algorithm */
+	if (algo) {
 		if (strcmp(algo, "TA_AES_ALGO_ECB") == 0) {
 			ctx.algo_num = TA_AES_ALGO_ECB;
+			printf("Algorithm: TA_AES_ALGO_ECB (from command line)\n");
 		} else if (strcmp(algo, "TA_AES_ALGO_CBC") == 0) {
 			ctx.algo_num = TA_AES_ALGO_CBC;
+			printf("Algorithm: TA_AES_ALGO_CBC (from command line)\n");
 		} else if (strcmp(algo, "TA_AES_ALGO_CTR") == 0) {
 			ctx.algo_num = TA_AES_ALGO_CTR;
+			printf("Algorithm: TA_AES_ALGO_CTR (from command line)\n");
 		} else if (strcmp(algo, "TA_AES_ALGO_CCM") == 0) {
 			ctx.algo_num = TA_AES_ALGO_CCM;
+			printf("Algorithm: TA_AES_ALGO_CCM (from command line)\n");
 		} else if (strcmp(algo, "TA_AES_ALGO_GCM") == 0) {
 			ctx.algo_num = TA_AES_ALGO_GCM;
+			printf("Algorithm: TA_AES_ALGO_GCM (from command line)\n");
 		} else {
-			printf("%s algo is invalid\n", algo);
+			fprintf(stderr, "Error: Invalid algorithm '%s'\n",
+				algo);
+			fprintf(stderr,
+				"Valid algorithms: TA_AES_ALGO_ECB, TA_AES_ALGO_CBC, TA_AES_ALGO_CTR, TA_AES_ALGO_CCM, TA_AES_ALGO_GCM\n");
 			return -1;
 		}
 	} else {
-		printf("TA_AES_ALGO_CTR algo selected\n");
 		ctx.algo_num = TA_AES_ALGO_CTR;
+		printf("Algorithm: TA_AES_ALGO_CTR (default)\n");
 	}
 
+	/* Initialize key - use default, then override if provided */
+	memset(key, 0xa5, AES_TEST_KEY_SIZE);
+	if (key_hex) {
+		int ret = hex_to_bytes(key_hex, (uint8_t *)key, AES_TEST_KEY_SIZE);
+
+		if (ret < 0 || ret != AES_TEST_KEY_SIZE) {
+			if (ret >= 0)
+				fprintf(stderr, "Error: KEY must be 16 bytes (32 hex chars), got %d bytes\n", ret);
+			return -1;
+		}
+		printf("Using key from: command line\n");
+	} else {
+		printf("Using key from: default (0xa5 repeated)\n");
+	}
+
+	/* Initialize IV - use default, then override if provided */
+	if (ctx.algo_num == TA_AES_ALGO_CCM || ctx.algo_num == TA_AES_ALGO_GCM) {
+		memset(iv, 0, 12);
+		iv_len = 12;
+	} else {
+		memset(iv, 0, AES_BLOCK_SIZE);
+		iv_len = AES_BLOCK_SIZE;
+	}
+
+	if (iv_hex) {
+		int expected_iv_len = (ctx.algo_num == TA_AES_ALGO_CCM || ctx.algo_num == TA_AES_ALGO_GCM) ? 12 : AES_BLOCK_SIZE;
+		int ret = hex_to_bytes(iv_hex, (uint8_t *)iv, expected_iv_len);
+
+		if (ret < 0 || ret != expected_iv_len) {
+			if (ret >= 0)
+				fprintf(stderr, "Error: IV must be %d bytes (%d hex chars), got %d bytes\n",
+					expected_iv_len, expected_iv_len * 2, ret);
+			return -1;
+		}
+		iv_len = expected_iv_len;
+		printf("Using IV from: command line\n");
+	} else {
+		printf("Using IV from: default (zeros)\n");
+	}
+
+	/* Handle input data */
+	if (input_file) {
+		/* Read from file */
+		if (read_file_contents(input_file, &file_buffer, &input_len) != 0) {
+			return -1;
+		}
+		original_len = input_len;
+		printf("Using data from: file (%s, %zu bytes)\n", input_file, input_len);
+	} else {
+		/* Use default pattern - point file_buffer to stack clear */
+		memset(clear, 0x5a, AES_TEST_BUFFER_SIZE);
+		input_len = AES_TEST_BUFFER_SIZE;
+		original_len = input_len;
+		file_buffer = (uint8_t *)clear;
+		printf("Using data from: default (0x5a repeated, %zu bytes)\n", input_len);
+	}
+
+	/* Allocate output buffers based on input size */
+	if ((ctx.algo_num == TA_AES_ALGO_CCM) ||
+	    (ctx.algo_num == TA_AES_ALGO_GCM)) {
+		/* For AE modes - add one block size for alignment overhead */
+		ct_len = input_len + AES_BLOCK_SIZE;
+		ciphertext = malloc(ct_len);
+		if (!ciphertext) {
+			fprintf(stderr, "Error: Cannot allocate ciphertext buffer\n");
+			if (file_buffer != (uint8_t *)clear)
+				free(file_buffer);
+			return -1;
+		}
+		dec_len = input_len + AES_BLOCK_SIZE;
+		decrypted = malloc(dec_len);
+		if (!decrypted) {
+			fprintf(stderr, "Error: Cannot allocate decrypted buffer\n");
+			free(ciphertext);
+			if (file_buffer != (uint8_t *)clear)
+				free(file_buffer);
+			return -1;
+		}
+	} else {
+		/* For traditional modes - pad to block size */
+		size_t padded_len = input_len;
+
+		if (input_len % AES_BLOCK_SIZE != 0) {
+			padded_len = ((input_len + AES_BLOCK_SIZE - 1) /
+				      AES_BLOCK_SIZE) * AES_BLOCK_SIZE;
+		}
+
+		ciph = malloc(padded_len);
+		if (!ciph) {
+			fprintf(stderr, "Error: Cannot allocate cipher buffer\n");
+			if (file_buffer != (uint8_t *)clear)
+				free(file_buffer);
+			return -1;
+		}
+
+		temp = malloc(padded_len);
+		if (!temp) {
+			fprintf(stderr, "Error: Cannot allocate temp buffer\n");
+			free(ciph);
+			if (file_buffer != (uint8_t *)clear)
+				free(file_buffer);
+			return -1;
+		}
+
+		/* If padding needed, create a padded copy */
+		if (padded_len > input_len) {
+			uint8_t *padded_buffer = malloc(padded_len);
+
+			if (!padded_buffer) {
+				fprintf(stderr, "Error: Cannot allocate padded buffer\n");
+				free(ciph);
+				free(temp);
+				if (file_buffer != (uint8_t *)clear)
+					free(file_buffer);
+				return -1;
+			}
+			memcpy(padded_buffer, file_buffer, input_len);
+			memset(padded_buffer + input_len, 0, padded_len - input_len);
+			/* Only free file_buffer if it was dynamically allocated */
+			if (file_buffer != (uint8_t *)clear)
+				free(file_buffer);
+			file_buffer = padded_buffer;
+			input_len = padded_len;
+		}
+	}
 	printf("Prepare session with the TA\n");
 	prepare_tee_session(&ctx);
 
@@ -226,56 +511,74 @@ int main(int argc, char *argv[])
 	prepare_aes(&ctx, ENCODE);
 
 	printf("Load key in TA\n");
-	memset(key, 0xa5, sizeof(key)); /* Load some dummy value */
 	set_key(&ctx, key, AES_TEST_KEY_SIZE);
 
-	if ((ctx.algo_num == TA_AES_ALGO_CCM) || (ctx.algo_num == TA_AES_ALGO_GCM)) {
+	if ((ctx.algo_num == TA_AES_ALGO_CCM) ||
+	    (ctx.algo_num == TA_AES_ALGO_GCM)) {
+		/* For AE modes - set nonce via set_iv */
+		printf("Set nonce for AE mode (%zu bytes)\n", iv_len);
+		set_iv(&ctx, iv, iv_len);
+
 		printf("AE encode operation in TA\n");
-		auth_enc_op(&ctx, TA_AES_MODE_ENCODE, plaintext,
-			    strlen(plaintext),  ciphertext, &ct_len,
-			    tag, &tag_len);
+		auth_enc_op(&ctx, TA_AES_MODE_ENCODE, file_buffer, input_len,
+			    ciphertext, &ct_len, tag, &tag_len);
 	} else {
+		/* For traditional modes (CBC/CTR/ECB) */
 		printf("Reset ciphering operation in TA (provides the initial vector)\n");
-		memset(iv, 0, sizeof(iv)); /* Load some dummy value */
-		set_iv(&ctx, iv, AES_BLOCK_SIZE);
+		set_iv(&ctx, iv, iv_len);
+
 		printf("Encode buffer from TA\n");
-		memset(clear, 0x5a, sizeof(clear)); /* Load some dummy value */
-		cipher_buffer(&ctx, clear, ciph, AES_TEST_BUFFER_SIZE);
+		cipher_buffer(&ctx, (char *)file_buffer, (char *)ciph, input_len);
 	}
 
 	printf("Prepare decode operation\n");
 	prepare_aes(&ctx, DECODE);
 
 	printf("Load key in TA\n");
-	memset(key, 0xa5, sizeof(key)); /* Load some dummy value */
 	set_key(&ctx, key, AES_TEST_KEY_SIZE);
 
-	if ((ctx.algo_num == TA_AES_ALGO_CCM) || (ctx.algo_num == TA_AES_ALGO_GCM)) {
+	if ((ctx.algo_num == TA_AES_ALGO_CCM) ||
+	    (ctx.algo_num == TA_AES_ALGO_GCM)) {
+		/* Reload nonce for decode */
+		printf("Set nonce for AE mode (%zu bytes)\n", iv_len);
+		set_iv(&ctx, iv, iv_len);
+
 		printf("AE decode operation in TA\n");
-		auth_enc_op(&ctx, TA_AES_MODE_DECODE, ciphertext, ct_len, decrypted,
-			     &dec_len, tag, &tag_len);
+		auth_enc_op(&ctx, TA_AES_MODE_DECODE, ciphertext, ct_len,
+			    decrypted, &dec_len, tag, &tag_len);
 	} else {
+		/* Reload IV for decode */
 		printf("Reset ciphering operation in TA (provides the initial vector)\n");
-		memset(iv, 0, sizeof(iv)); /* Load some dummy value */
-		set_iv(&ctx, iv, AES_BLOCK_SIZE);
+		set_iv(&ctx, iv, iv_len);
+
 		printf("Decode buffer from TA\n");
-		cipher_buffer(&ctx, ciph, temp, AES_TEST_BUFFER_SIZE);
+		cipher_buffer(&ctx, (char *)ciph, (char *)temp, input_len);
 	}
 
 	/* Check decoded is the clear content */
-	if ((ctx.algo_num == TA_AES_ALGO_CCM) || (ctx.algo_num == TA_AES_ALGO_GCM)) {
-		if (memcmp(plaintext, decrypted, strlen(plaintext)) == 0)
-			printf("CCM encryption/decryption successful!\n");
+	if ((ctx.algo_num == TA_AES_ALGO_CCM) ||
+	    (ctx.algo_num == TA_AES_ALGO_GCM)) {
+		if (memcmp(file_buffer, decrypted, original_len) == 0)
+			printf("CCM/GCM encryption/decryption successful!\n");
 		else
-			printf("Decryption failed or tag mismatch!\n");
-
+			printf("Decrypted plaintext mismatch — unexpected internal error\n");
 	} else {
-		if (memcmp(clear, temp, AES_TEST_BUFFER_SIZE))
+		if (memcmp(file_buffer, temp, original_len))
 			printf("Clear text and decoded text differ => ERROR\n");
 		else
 			printf("Clear text and decoded text match\n");
 	}
 
 	terminate_tee_session(&ctx);
+
+	/* Clean up allocated buffers */
+	if (file_buffer != (uint8_t *)clear)
+		free(file_buffer);
+
+	free(ciphertext);
+	free(decrypted);
+	free(ciph);
+	free(temp);
+
 	return 0;
 }

--- a/aes/ta/aes_ta.c
+++ b/aes/ta/aes_ta.c
@@ -28,6 +28,8 @@ struct aes_cipher {
 	uint32_t key_size;		/* AES key size in byte */
 	TEE_OperationHandle op_handle;	/* AES ciphering operation */
 	TEE_ObjectHandle key_handle;	/* transient object to load the key */
+	uint8_t nonce[16];		/* Stored nonce/IV for AE modes */
+	size_t nonce_len;		/* Nonce length */
 };
 
 /*
@@ -134,6 +136,14 @@ static TEE_Result alloc_resources(void *session, uint32_t param_types,
 
 	/* Free potential previous operation */
 	TEE_FreeOperation(sess->op_handle);
+	sess->op_handle = TEE_HANDLE_NULL;
+
+	/* Free potential previous transient object */
+	TEE_FreeTransientObject(sess->key_handle);
+	sess->key_handle = TEE_HANDLE_NULL;
+
+	/* Reset nonce state from previous operation */
+	sess->nonce_len = 0;
 
 	/* Allocate operation: AES/CTR, mode and size from params */
 	res = TEE_AllocateOperation(&sess->op_handle,
@@ -145,9 +155,6 @@ static TEE_Result alloc_resources(void *session, uint32_t param_types,
 		sess->op_handle = TEE_HANDLE_NULL;
 		goto err;
 	}
-
-	/* Free potential previous transient object */
-	TEE_FreeTransientObject(sess->key_handle);
 
 	/* Allocate transient object according to target key size */
 	res = TEE_AllocateTransientObject(TEE_TYPE_AES,
@@ -298,9 +305,23 @@ static TEE_Result reset_aes_iv(void *session, uint32_t param_types,
 	iv_sz = params[0].memref.size;
 
 	/*
-	 * Init cipher operation with the initialization vector.
+	 * For CCM/GCM modes, store the nonce for later use in auth_enc_op.
+	 * For traditional modes, initialize cipher operation with IV.
 	 */
-	TEE_CipherInit(sess->op_handle, iv, iv_sz);
+	if (sess->algo == TEE_ALG_AES_CCM || sess->algo == TEE_ALG_AES_GCM) {
+		/* Store nonce for authenticated encryption modes */
+		if (iv_sz > sizeof(sess->nonce)) {
+			EMSG("Nonce size %zu too large (max %zu)", iv_sz,
+			     sizeof(sess->nonce));
+			return TEE_ERROR_BAD_PARAMETERS;
+		}
+		TEE_MemMove(sess->nonce, iv, iv_sz);
+		sess->nonce_len = iv_sz;
+		DMSG("Stored nonce for AE mode (%zu bytes)", iv_sz);
+	} else {
+		/* Traditional modes: initialize cipher operation with IV */
+		TEE_CipherInit(sess->op_handle, iv, iv_sz);
+	}
 
 	return TEE_SUCCESS;
 }
@@ -346,18 +367,14 @@ static TEE_Result cipher_buffer(void *session, uint32_t param_types,
 static TEE_Result auth_enc_op(void *session, uint32_t param_types, TEE_Param params[4])
 {
 	struct aes_cipher *sess = session;
-	TEE_Result res = TEE_ERROR_OUT_OF_MEMORY;
+	TEE_Result res = TEE_ERROR_GENERIC;
 	size_t tag_len = 0;
 	size_t out_len = 0;
 	void *in_buf = NULL;
 	size_t in_sz = 0;
 	bool encrypt = true;
-	void *b2 = NULL;
-	void *b3 = NULL;
-	uint8_t nonce[12] = {
-		0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
-		0x08, 0x09, 0x0A, 0x0B
-	};
+	uint8_t *nonce = NULL;
+	size_t nonce_len = 0;
 	const uint32_t expected_pt =
 		TEE_PARAM_TYPES(TEE_PARAM_TYPE_MEMREF_INPUT,
 				TEE_PARAM_TYPE_MEMREF_OUTPUT,
@@ -373,72 +390,54 @@ static TEE_Result auth_enc_op(void *session, uint32_t param_types, TEE_Param par
 	in_sz = params[0].memref.size;
 	encrypt = (params[2].value.a != 0);
 
-	if (params[1].memref.buffer && params[1].memref.size) {
-		b2 = TEE_Malloc(params[1].memref.size, 0);
-		if (!b2)
-			goto out;
+	/* Use stored nonce if available, otherwise use default */
+	if (sess->nonce_len > 0) {
+		nonce = sess->nonce;
+		nonce_len = sess->nonce_len;
+		DMSG("Using stored nonce (%zu bytes)", nonce_len);
+	} else {
+		/* Default nonce for backward compatibility */
+		static uint8_t default_nonce[12] = {
+			0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
+			0x08, 0x09, 0x0A, 0x0B
+		};
+
+		nonce = default_nonce;
+		nonce_len = sizeof(default_nonce);
+		DMSG("Using default nonce (%zu bytes)", nonce_len);
 	}
 
 	DMSG("Initializing an Authentication Encryption operation");
 
-	res = TEE_AEInit(sess->op_handle, nonce, sizeof(nonce),
+	res = TEE_AEInit(sess->op_handle, nonce, nonce_len,
 			 tag_len * 8, 0, in_sz);
-
 	if (res != TEE_SUCCESS)
-		goto out;
+		return res;
 
 	if (encrypt) {
-		if (params[3].memref.buffer && params[3].memref.size) {
-			b3 = TEE_Malloc(params[3].memref.size, 0);
-			if (!b3) {
-				res = TEE_ERROR_OUT_OF_MEMORY;
-				goto out;
-			}
-		}
 		DMSG("AE Encryption");
 		res = TEE_AEEncryptFinal(sess->op_handle,
 					 in_buf, in_sz,
-					 b2, &out_len,
-					 b3, &tag_len);
-
+					 params[1].memref.buffer, &out_len,
+					 params[3].memref.buffer, &tag_len);
 		if (res == TEE_SUCCESS) {
-			if (b2) {
-				TEE_MemMove(params[1].memref.buffer, b2,
-					    out_len);
-			}
-			if (b3) {
-				TEE_MemMove(params[3].memref.buffer, b3,
-					    tag_len);
-			}
-
 			params[1].memref.size = out_len;
 			params[3].memref.size = tag_len;
 		} else {
 			EMSG("TEE_AEEncryptFinal failed with %#"PRIx32, res);
 		}
 	} else {
-
 		DMSG("AE Decryption");
 		res = TEE_AEDecryptFinal(sess->op_handle,
 					 in_buf, in_sz,
-					 b2, &out_len,
-					 params[3].memref.buffer,
-					 tag_len);
+					 params[1].memref.buffer, &out_len,
+					 params[3].memref.buffer, tag_len);
 		if (res == TEE_SUCCESS) {
-
-			if (b2) {
-				TEE_MemMove(params[1].memref.buffer, b2,
-					    out_len);
-			}
-
 			params[1].memref.size = out_len;
 		} else {
 			EMSG("TEE_AEDecryptFinal failed with %#"PRIx32, res);
 		}
 	}
-out:
-	TEE_Free(b2);
-	TEE_Free(b3);
 
 	return res;
 }
@@ -471,6 +470,7 @@ TEE_Result TA_OpenSessionEntryPoint(uint32_t __unused param_types,
 
 	sess->key_handle = TEE_HANDLE_NULL;
 	sess->op_handle = TEE_HANDLE_NULL;
+	sess->nonce_len = 0;  /* Initialize nonce fields */
 
 	*session = (void *)sess;
 	DMSG("Session %p: newly allocated", *session);

--- a/aes/ta/include/aes_ta.h
+++ b/aes/ta/include/aes_ta.h
@@ -43,14 +43,14 @@
 #define TA_AES_CMD_SET_KEY		1
 
 /*
- * TA_AES_CMD_SET_IV - reset IV
- * param[0] (memref) initial vector, size shall equal block length
+ * TA_AES_CMD_SET_IV - set IV or nonce instead of using default test value
+ * param[0] (memref) initial vector (ciphering, size shall equal block length)
+ *                   or nonce (authenticated encryption, size shall be 12 bytes).
  * param[1] unused
  * param[2] unused
  * param[3] unused
  */
 #define TA_AES_CMD_SET_IV		2
-
 /*
  * TA_AES_CMD_CIPHER - Cipher input buffer into output buffer
  * param[0] (memref) input buffer


### PR DESCRIPTION
This patch adds support for encrypting files and specifying keys/IVs directly on the command line, replacing the previous keyfile approach.

Features:
=========
- --input-file: Encrypt any file
- --key: Specify 16-byte key as hex string (32 chars)
- --iv: Specify IV/nonce as hex string (16 bytes for CBC/CTR/ECB, 12 bytes for CCM/GCM)
- All options are optional with sensible defaults
- Automatic padding for block-aligned encryption

Usage Examples:
===============
optee_example_aes

optee_example_aes --algo TA_AES_ALGO_CBC --input-file document.txt

optee_example_aes --algo TA_AES_ALGO_CBC \
  --key 0123456789abcdef0123456789abcdef \
  --iv fedcba9876543210fedcba9876543210

optee_example_aes --algo TA_AES_ALGO_GCM \
  --input-file secret.dat \
  --key feffe9928665731c6d6a8f9467308308 \
  --iv cafebabefacedbaddecaf888

Defaults:
=========
- Algorithm: AES_CTR
- Key: 0xa5 pattern (16 bytes)
- IV/Nonce: 0x00 pattern
- Input: 0x5a pattern (4096 bytes)