### PR TITLE
acipher: fix decryption output size probe using non-NULL buffer

### DIFF
--- a/acipher/ta/acipher_ta.c
+++ b/acipher/ta/acipher_ta.c
@@ -119,12 +119,46 @@ static TEE_Result cmd_enc(struct acipher *state, uint32_t pt,
 			     params[1].memref.size, res);
 		}
 	} else {
-		res = TEE_AsymmetricDecrypt(op, NULL, 0, inbuf, inbuf_len,
-					    outbuf, &outbuf_len);
-		if (res) {
-			EMSG("TEE_AsymmetricDecrypt(%" PRId32 ", %"
-			     PRId32 "): %#" PRIx32, inbuf_len,
-			     params[1].memref.size, res);
+		if (!outbuf) {
+			/*
+			 * Size-probe call: the host passes a NULL output buffer
+			 * to query the required plaintext length.
+			 * TEE_AsymmetricDecrypt() rejects a NULL destination
+			 * pointer with TEE_ERROR_BAD_PARAMETERS before it can
+			 * compute the output size.  Allocate a temporary
+			 * internal buffer sized to the maximum RSA output
+			 * (key modulus bytes), run the full decryption into it
+			 * to obtain the exact plaintext length, then free it
+			 * and return TEE_ERROR_SHORT_BUFFER so the host can
+			 * re-invoke with a correctly-sized output buffer.
+			 */
+			uint8_t *tmp_buf = NULL;
+
+			outbuf_len = key_info.keySize / 8;
+			tmp_buf = TEE_Malloc(outbuf_len, 0);
+			if (!tmp_buf) {
+				res = TEE_ERROR_OUT_OF_MEMORY;
+				goto out;
+			}
+			res = TEE_AsymmetricDecrypt(op, NULL, 0, inbuf,
+						    inbuf_len, tmp_buf,
+						    &outbuf_len);
+			TEE_Free(tmp_buf);
+			if (res != TEE_SUCCESS) {
+				EMSG("TEE_AsymmetricDecrypt size probe failed: %#"
+				     PRIx32, res);
+				goto out;
+			}
+			res = TEE_ERROR_SHORT_BUFFER;
+		} else {
+			res = TEE_AsymmetricDecrypt(op, NULL, 0, inbuf,
+						    inbuf_len, outbuf,
+						    &outbuf_len);
+			if (res) {
+				EMSG("TEE_AsymmetricDecrypt(%" PRId32 ", %"
+				     PRId32 "): %#" PRIx32, inbuf_len,
+				     params[1].memref.size, res);
+			}
 		}
 	}
 	params[1].memref.size = outbuf_len;


### PR DESCRIPTION
The two-phase size-probe pattern for encryption works by passing a NULL output buffer on the first call; crypto_acipher_rsaes_encrypt() detects that the reported output size is smaller than the key modulus and returns TEE_ERROR_SHORT_BUFFER before inspecting the pointer itself.

The decryption path does not follow the same pattern. crypto_acipher_rsaes_decrypt() validates all pointer arguments up front:

  if (!key || !msg || !cipher || !msg_len || ...)
	  return TEE_ERROR_BAD_PARAMETERS;

A NULL output pointer therefore returns TEE_ERROR_BAD_PARAMETERS before the required size can be computed, and the host receives TEEC_ERROR_BAD_PARAMETERS instead of the expected
TEEC_ERROR_SHORT_BUFFER, causing a fatal error on the first probe call.

PKCS#11 avoids this problem implicitly: TEEC_AllocateSharedMemory() enforces a minimum allocation of 8 bytes, so a zero-length output SHM always carries a non-NULL buffer pointer into the TA.  The non-NULL pointer passes the validation guard, the decrypt runs against a temporary internal buffer, and TEE_ERROR_SHORT_BUFFER is returned with the exact plaintext length.

Apply the same approach explicitly for the acipher example: allocate a small probe buffer (DEC_OUT_SIZE_PROBE_LEN bytes) and set the reported size to zero.  The non-NULL pointer satisfies the guard, the full decryption executes into the TA's internal buffer, and the required output size is returned via SHORT_BUFFER.  The probe buffer is freed before allocating the correctly-sized output buffer for the second call.

Fixes: 934c7ed ("acipher: Add dynamic algorithm selection and decryption support")